### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*          @grafana/asserts-team


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` assigning `@grafana/asserts-team` as owner of all files in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)