### PR TITLE
chore(ci): bump GitHub Actions versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
           persist-credentials: true
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: 1.23
+          go-version: 1.25
 
       - name: Generate Client
         uses: grafana/shared-workflows/actions/generate-openapi-clients@8ef55db5803bf7fc92e32ca4a4f488657f3f53fe #v1.1.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,8 @@ jobs:
 
       - name: Generate Client
         uses: grafana/shared-workflows/actions/generate-openapi-clients@8ef55db5803bf7fc92e32ca4a4f488657f3f53fe #v1.1.0
+        env:
+          REPO_NAME: ${{ github.event.repository.name }}
         with:
           package-name: gcom
           spec-path: openapi.yaml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,15 +16,15 @@ jobs:
   build-and-publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: true
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: 1.23
 
       - name: Generate Client
-        uses: grafana/shared-workflows/actions/generate-openapi-clients@da511b720bc646fe01a29ddaf37e92df2c4bacb3
+        uses: grafana/shared-workflows/actions/generate-openapi-clients@8ef55db5803bf7fc92e32ca4a4f488657f3f53fe #v1.1.0
         with:
           package-name: gcom
           spec-path: openapi.yaml

--- a/go/gcom/model_api_validation_error.go
+++ b/go/gcom/model_api_validation_error.go
@@ -130,7 +130,7 @@ func (o *ApiValidationError) GetRejectedValueOk() (*interface{}, bool) {
 
 // HasRejectedValue returns a boolean if a field has been set.
 func (o *ApiValidationError) HasRejectedValue() bool {
-	if o != nil && IsNil(o.RejectedValue) {
+	if o != nil && !IsNil(o.RejectedValue) {
 		return true
 	}
 

--- a/go/gcom/model_assertion_scores_dto.go
+++ b/go/gcom/model_assertion_scores_dto.go
@@ -229,7 +229,7 @@ func (o *AssertionScoresDto) GetGraphDataOk() (*interface{}, bool) {
 
 // HasGraphData returns a boolean if a field has been set.
 func (o *AssertionScoresDto) HasGraphData() bool {
-	if o != nil && IsNil(o.GraphData) {
+	if o != nil && !IsNil(o.GraphData) {
 		return true
 	}
 

--- a/go/gcom/model_entity_assertion_summaries_dto.go
+++ b/go/gcom/model_entity_assertion_summaries_dto.go
@@ -229,7 +229,7 @@ func (o *EntityAssertionSummariesDto) GetGraphDataOk() (*interface{}, bool) {
 
 // HasGraphData returns a boolean if a field has been set.
 func (o *EntityAssertionSummariesDto) HasGraphData() bool {
-	if o != nil && IsNil(o.GraphData) {
+	if o != nil && !IsNil(o.GraphData) {
 		return true
 	}
 

--- a/go/gcom/model_entity_assertions_graph_dto.go
+++ b/go/gcom/model_entity_assertions_graph_dto.go
@@ -130,7 +130,7 @@ func (o *EntityAssertionsGraphDto) GetDataOk() (*interface{}, bool) {
 
 // HasData returns a boolean if a field has been set.
 func (o *EntityAssertionsGraphDto) HasData() bool {
-	if o != nil && IsNil(o.Data) {
+	if o != nil && !IsNil(o.Data) {
 		return true
 	}
 

--- a/go/gcom/model_property_matcher_dto.go
+++ b/go/gcom/model_property_matcher_dto.go
@@ -93,7 +93,7 @@ func (o *PropertyMatcherDto) GetValueOk() (*interface{}, bool) {
 
 // HasValue returns a boolean if a field has been set.
 func (o *PropertyMatcherDto) HasValue() bool {
-	if o != nil && IsNil(o.Value) {
+	if o != nil && !IsNil(o.Value) {
 		return true
 	}
 

--- a/go/gcom/model_search_response_dto.go
+++ b/go/gcom/model_search_response_dto.go
@@ -164,7 +164,7 @@ func (o *SearchResponseDto) GetDataOk() (*interface{}, bool) {
 
 // HasData returns a boolean if a field has been set.
 func (o *SearchResponseDto) HasData() bool {
-	if o != nil && IsNil(o.Data) {
+	if o != nil && !IsNil(o.Data) {
 		return true
 	}
 


### PR DESCRIPTION
This pull request updates the versions of GitHub Actions used for:

- `checkout` action
- `setup-go` action
- OpenAPI client generation, coming from our shared-workflows