### PR TITLE
ci: sign generated-client commits via createCommitOnBranch

### DIFF
--- a/.github/workflows/commit-signed-changes.sh
+++ b/.github/workflows/commit-signed-changes.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Commits all working-tree changes as a single commit via the GitHub GraphQL
+# createCommitOnBranch mutation. Commits created through the API are signed by
+# GitHub and show as "Verified", which satisfies the repository's "Signed
+# Commits" ruleset. The git-based auto-commit action cannot satisfy that rule
+# without a provisioned signing key, so we commit through the API instead.
+#
+# Required env:
+#   TARGET_BRANCH      branch to commit onto (e.g. the PR head or release branch)
+#   GH_TOKEN           token with contents:write for `gh api`
+#   GITHUB_REPOSITORY  owner/name (provided by GitHub Actions)
+# Optional env:
+#   COMMIT_MESSAGE     commit headline (default: "Update generated clients")
+
+BRANCH="${TARGET_BRANCH:?TARGET_BRANCH is required}"
+MESSAGE="${COMMIT_MESSAGE:-Update generated clients}"
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+
+git add -A
+
+if git diff --cached --quiet; then
+  echo "No changes to commit."
+  exit 0
+fi
+
+add_file="$(mktemp)"
+del_file="$(mktemp)"
+body_file="$(mktemp)"
+trap 'rm -f "$add_file" "$del_file" "$body_file"' EXIT
+
+# File contents are read with jq --rawfile (not the command line) so neither the
+# total payload nor any single large file trips the OS argument-length limit.
+# Rename detection is disabled so a rename surfaces as a delete + add, which maps
+# cleanly onto the mutation's separate additions/deletions inputs.
+git diff --cached --no-renames --name-only --diff-filter=ACM -z \
+  | while IFS= read -r -d '' path; do
+      jq -n --arg path "$path" --rawfile contents "$path" \
+        '{path: $path, contents: ($contents | @base64)}'
+    done \
+  | jq -s '.' >"$add_file"
+
+git diff --cached --no-renames --name-only --diff-filter=D -z \
+  | while IFS= read -r -d '' path; do
+      jq -n --arg path "$path" '{path: $path}'
+    done \
+  | jq -s '.' >"$del_file"
+
+expected_head_oid="$(git rev-parse HEAD)"
+
+echo "Committing $(jq 'length' "$add_file") additions and $(jq 'length' "$del_file") deletions to ${BRANCH} (parent ${expected_head_oid})."
+
+jq -n \
+  --arg query 'mutation ($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid url } } }' \
+  --arg repo "$GITHUB_REPOSITORY" \
+  --arg branch "$BRANCH" \
+  --arg oid "$expected_head_oid" \
+  --arg headline "$MESSAGE" \
+  --slurpfile additions "$add_file" \
+  --slurpfile deletions "$del_file" \
+  '{
+     query: $query,
+     variables: {
+       input: {
+         branch: { repositoryNameWithOwner: $repo, branchName: $branch },
+         message: { headline: $headline },
+         expectedHeadOid: $oid,
+         fileChanges: { additions: $additions[0], deletions: $deletions[0] }
+       }
+     }
+   }' >"$body_file"
+
+gh api graphql --input "$body_file"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,11 +18,15 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          persist-credentials: true
+          persist-credentials: false
+          # Check out the branch tip (not the PR merge ref) so the signed commit
+          # step can use HEAD as expectedHeadOid for createCommitOnBranch.
+          ref: ${{ github.head_ref || github.ref_name }}
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: 1.25
 
+      # Generation only — committing is done once, signed, in the step below.
       - name: Generate Client
         uses: grafana/shared-workflows/actions/generate-openapi-clients@8ef55db5803bf7fc92e32ca4a4f488657f3f53fe #v1.1.0
         env:
@@ -31,3 +35,15 @@ jobs:
           package-name: gcom
           spec-path: openapi.yaml
           modify-spec-script: .github/workflows/modify-spec.sh
+          commit-changes: "false"
+
+      # Commit via the GitHub API so the commit is signed/verified, satisfying
+      # the "Signed Commits" ruleset (a plain git push of a bot commit is not).
+      - name: Commit generated clients (signed)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_BRANCH: ${{ github.head_ref || github.ref_name }}
+          # [skip ci] avoids a redundant (and recursion-guarded) re-run on the
+          # generated commit; the run that produced it already validated it.
+          COMMIT_MESSAGE: "Update generated clients [skip ci]"
+        run: .github/workflows/commit-signed-changes.sh


### PR DESCRIPTION
## Summary

The `Generate Clients` publish workflow used a git-based auto-commit to push regenerated SDKs back to the branch. The repo's **Signed Commits** ruleset (`required_signatures`, applied to `~ALL` branches) rejects those pushes because a bot `git push` is unsigned, so the pipeline could not commit generated clients.

This PR makes the workflow commit **once, via the GitHub GraphQL `createCommitOnBranch` mutation**, which produces an API-signed/Verified commit that satisfies the ruleset:

- `commit-signed-changes.sh` — stages the working tree and commits it through `createCommitOnBranch` (reads file contents via `jq --rawfile` to stay clear of `ARG_MAX`; disables rename detection so renames map cleanly to add+delete).
- `publish.yml`:
  - checkout with `persist-credentials: false` and `ref: ${{ github.head_ref || github.ref_name }}` so the signed-commit step can use the branch tip `HEAD` as `expectedHeadOid`.
  - the generate step runs with `commit-changes: "false"` (generation only).
  - a new **Commit generated clients (signed)** step runs the script, using `[skip ci]` in the message to avoid a redundant re-run on the generated commit.

This is infrastructure shared by all generated clients (today `gcom`). The `kgwrite` client addition stacks on top of this in #90.

## Test plan

- [ ] Push to this branch triggers the workflow; generated `gcom` changes (if any) are committed as a single **Verified** commit.
- [ ] No "Signed Commits" ruleset rejection in the workflow logs.

Made with [Cursor](https://cursor.com)