### PR TITLE
fix: sanitize invalid $ref siblings so generated Go clients compile

### DIFF
--- a/.github/workflows/modify-spec.sh
+++ b/.github/workflows/modify-spec.sh
@@ -1,32 +1,50 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Read the input spec and fix the HttpStatus schema
-# Remove the problematic allOf structure and add type: string
-cat | awk '
-BEGIN { in_httpstatus = 0 }
+# Sanitizes a generated OpenAPI spec before it is handed to OpenAPI Generator.
+# Reads the spec on stdin and writes the cleaned spec to stdout.
+#
+# Two springdoc-emitted patterns break the generated Go client and are fixed here:
+#
+# 1. HttpStatus schema: rendered as `allOf` + a `$ref` to `HttpStatusCode`, which
+#    the generator can't turn into a usable Go type. Collapse it to a plain
+#    `type: string` enum.
+#
+# 2. `$ref` with sibling keywords: error responses reference `ApiError` via a
+#    `$ref` that also carries sibling `additionalProperties`/`default` keys. A
+#    `$ref` with sibling constraints is invalid OpenAPI (siblings are ignored
+#    unless wrapped in `allOf`), and the Go generator splices the
+#    additionalProperties map onto the referenced type name, emitting
+#    non-compiling code such as `ApiError[string]interface{}`. Drop those
+#    siblings so the reference resolves to the plain `ApiError` type. Only the
+#    `additionalProperties`/`default` keys are removed, and only from maps that
+#    contain a `$ref`, so legitimate inline `additionalProperties` schemas (e.g.
+#    deepObject `scope` params) are left untouched.
 
-# Start of HttpStatus section (with proper spacing)
-/[[:space:]]*HttpStatus:/ { 
+awk '
+  BEGIN { in_httpstatus = 0 }
+
+  # Start of the HttpStatus schema.
+  /[[:space:]]*HttpStatus:/ {
     in_httpstatus = 1
     print
-    next 
-}
+    next
+  }
 
-# End of HttpStatus section (next schema at same indentation level)
-in_httpstatus && /^    [A-Za-z][A-Za-z0-9]*:/ && !/HttpStatus:/ { 
-    in_httpstatus = 0 
-}
+  # Next schema at the same indentation ends the HttpStatus section.
+  in_httpstatus && /^    [A-Za-z][A-Za-z0-9]*:/ && !/HttpStatus:/ {
+    in_httpstatus = 0
+  }
 
-# Skip problematic lines in HttpStatus section
-in_httpstatus && /allOf:/ { next }
-in_httpstatus && /\$ref.*HttpStatusCode/ { next }
+  # Drop the unresolvable allOf / $ref structure.
+  in_httpstatus && /allOf:/ { next }
+  in_httpstatus && /\$ref.*HttpStatusCode/ { next }
 
-# Add type: string before enum in HttpStatus section
-in_httpstatus && /enum:/ { 
+  # Give the enum a concrete scalar type.
+  in_httpstatus && /enum:/ {
     print "      type: string"
-}
+  }
 
-# Print all other lines
-{ print }
-'
+  { print }
+' \
+  | yq '(.. | select(tag == "!!map" and has("$ref"))) |= (del(.additionalProperties) | del(.default))'

--- a/go/gcom/api_alert_configuration.go
+++ b/go/gcom/api_alert_configuration.go
@@ -20,14 +20,13 @@ import (
 	"strings"
 )
 
-
 // AlertConfigurationAPIService AlertConfigurationAPI service
 type AlertConfigurationAPIService service
 
 type ApiDeleteAlertConfigRequest struct {
-	ctx context.Context
-	ApiService *AlertConfigurationAPIService
-	name string
+	ctx         context.Context
+	ApiService  *AlertConfigurationAPIService
+	name        string
 	xScopeOrgID *string
 }
 
@@ -46,24 +45,24 @@ DeleteAlertConfig Delete an alert configuration by name
 
 Deletes a specific alert configuration identified by its name.
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param name The name of the alert configuration to delete
- @return ApiDeleteAlertConfigRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param name The name of the alert configuration to delete
+	@return ApiDeleteAlertConfigRequest
 */
 func (a *AlertConfigurationAPIService) DeleteAlertConfig(ctx context.Context, name string) ApiDeleteAlertConfigRequest {
 	return ApiDeleteAlertConfigRequest{
 		ApiService: a,
-		ctx: ctx,
-		name: name,
+		ctx:        ctx,
+		name:       name,
 	}
 }
 
 // Execute executes the request
 func (a *AlertConfigurationAPIService) DeleteAlertConfigExecute(r ApiDeleteAlertConfigRequest) (*http.Response, error) {
 	var (
-		localVarHTTPMethod   = http.MethodDelete
-		localVarPostBody     interface{}
-		formFiles            []formFile
+		localVarHTTPMethod = http.MethodDelete
+		localVarPostBody   interface{}
+		formFiles          []formFile
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "AlertConfigurationAPIService.DeleteAlertConfig")
@@ -121,14 +120,14 @@ func (a *AlertConfigurationAPIService) DeleteAlertConfigExecute(r ApiDeleteAlert
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
-			var v ApiError[string]interface{}
+			var v ApiError
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarHTTPResponse, newErr
 			}
-					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-					newErr.model = v
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
 		}
 		return localVarHTTPResponse, newErr
 	}
@@ -137,9 +136,9 @@ func (a *AlertConfigurationAPIService) DeleteAlertConfigExecute(r ApiDeleteAlert
 }
 
 type ApiDeleteDisabledAlertConfigRequest struct {
-	ctx context.Context
-	ApiService *AlertConfigurationAPIService
-	name string
+	ctx         context.Context
+	ApiService  *AlertConfigurationAPIService
+	name        string
 	xScopeOrgID *string
 }
 
@@ -158,24 +157,24 @@ DeleteDisabledAlertConfig Re-enable an alert configuration by name
 
 Deletes a 'disabled' configuration, which re-enables the alert.
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param name The name of the disabled alert to re-enable
- @return ApiDeleteDisabledAlertConfigRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param name The name of the disabled alert to re-enable
+	@return ApiDeleteDisabledAlertConfigRequest
 */
 func (a *AlertConfigurationAPIService) DeleteDisabledAlertConfig(ctx context.Context, name string) ApiDeleteDisabledAlertConfigRequest {
 	return ApiDeleteDisabledAlertConfigRequest{
 		ApiService: a,
-		ctx: ctx,
-		name: name,
+		ctx:        ctx,
+		name:       name,
 	}
 }
 
 // Execute executes the request
 func (a *AlertConfigurationAPIService) DeleteDisabledAlertConfigExecute(r ApiDeleteDisabledAlertConfigRequest) (*http.Response, error) {
 	var (
-		localVarHTTPMethod   = http.MethodDelete
-		localVarPostBody     interface{}
-		formFiles            []formFile
+		localVarHTTPMethod = http.MethodDelete
+		localVarPostBody   interface{}
+		formFiles          []formFile
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "AlertConfigurationAPIService.DeleteDisabledAlertConfig")
@@ -233,14 +232,14 @@ func (a *AlertConfigurationAPIService) DeleteDisabledAlertConfigExecute(r ApiDel
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
-			var v ApiError[string]interface{}
+			var v ApiError
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarHTTPResponse, newErr
 			}
-					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-					newErr.model = v
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
 		}
 		return localVarHTTPResponse, newErr
 	}
@@ -249,8 +248,8 @@ func (a *AlertConfigurationAPIService) DeleteDisabledAlertConfigExecute(r ApiDel
 }
 
 type ApiGetAllAlertConfigsRequest struct {
-	ctx context.Context
-	ApiService *AlertConfigurationAPIService
+	ctx         context.Context
+	ApiService  *AlertConfigurationAPIService
 	xScopeOrgID *string
 }
 
@@ -260,7 +259,7 @@ func (r ApiGetAllAlertConfigsRequest) XScopeOrgID(xScopeOrgID string) ApiGetAllA
 	return r
 }
 
-func (r ApiGetAllAlertConfigsRequest) Execute() (AlertConfigsDto[string]interface{}, *http.Response, error) {
+func (r ApiGetAllAlertConfigsRequest) Execute() (*AlertConfigsDto, *http.Response, error) {
 	return r.ApiService.GetAllAlertConfigsExecute(r)
 }
 
@@ -269,24 +268,25 @@ GetAllAlertConfigs Get all alert configurations
 
 Retrieves a list of all alert configurations for the tenant.
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiGetAllAlertConfigsRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiGetAllAlertConfigsRequest
 */
 func (a *AlertConfigurationAPIService) GetAllAlertConfigs(ctx context.Context) ApiGetAllAlertConfigsRequest {
 	return ApiGetAllAlertConfigsRequest{
 		ApiService: a,
-		ctx: ctx,
+		ctx:        ctx,
 	}
 }
 
 // Execute executes the request
-//  @return AlertConfigsDto[string]interface{}
-func (a *AlertConfigurationAPIService) GetAllAlertConfigsExecute(r ApiGetAllAlertConfigsRequest) (AlertConfigsDto[string]interface{}, *http.Response, error) {
+//
+//	@return AlertConfigsDto
+func (a *AlertConfigurationAPIService) GetAllAlertConfigsExecute(r ApiGetAllAlertConfigsRequest) (*AlertConfigsDto, *http.Response, error) {
 	var (
-		localVarHTTPMethod   = http.MethodGet
-		localVarPostBody     interface{}
-		formFiles            []formFile
-		localVarReturnValue  AlertConfigsDto[string]interface{}
+		localVarHTTPMethod  = http.MethodGet
+		localVarPostBody    interface{}
+		formFiles           []formFile
+		localVarReturnValue *AlertConfigsDto
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "AlertConfigurationAPIService.GetAllAlertConfigs")
@@ -343,14 +343,14 @@ func (a *AlertConfigurationAPIService) GetAllAlertConfigsExecute(r ApiGetAllAler
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
-			var v ApiError[string]interface{}
+			var v ApiError
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
 			}
-					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-					newErr.model = v
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
 		}
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
@@ -368,8 +368,8 @@ func (a *AlertConfigurationAPIService) GetAllAlertConfigsExecute(r ApiGetAllAler
 }
 
 type ApiGetAllDisabledAlertConfigsRequest struct {
-	ctx context.Context
-	ApiService *AlertConfigurationAPIService
+	ctx         context.Context
+	ApiService  *AlertConfigurationAPIService
 	xScopeOrgID *string
 }
 
@@ -379,7 +379,7 @@ func (r ApiGetAllDisabledAlertConfigsRequest) XScopeOrgID(xScopeOrgID string) Ap
 	return r
 }
 
-func (r ApiGetAllDisabledAlertConfigsRequest) Execute() (DisabledAlertConfigsDto[string]interface{}, *http.Response, error) {
+func (r ApiGetAllDisabledAlertConfigsRequest) Execute() (*DisabledAlertConfigsDto, *http.Response, error) {
 	return r.ApiService.GetAllDisabledAlertConfigsExecute(r)
 }
 
@@ -388,24 +388,25 @@ GetAllDisabledAlertConfigs Get all disabled alert configurations
 
 Retrieves a list of all currently disabled alert configurations for the tenant.
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiGetAllDisabledAlertConfigsRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiGetAllDisabledAlertConfigsRequest
 */
 func (a *AlertConfigurationAPIService) GetAllDisabledAlertConfigs(ctx context.Context) ApiGetAllDisabledAlertConfigsRequest {
 	return ApiGetAllDisabledAlertConfigsRequest{
 		ApiService: a,
-		ctx: ctx,
+		ctx:        ctx,
 	}
 }
 
 // Execute executes the request
-//  @return DisabledAlertConfigsDto[string]interface{}
-func (a *AlertConfigurationAPIService) GetAllDisabledAlertConfigsExecute(r ApiGetAllDisabledAlertConfigsRequest) (DisabledAlertConfigsDto[string]interface{}, *http.Response, error) {
+//
+//	@return DisabledAlertConfigsDto
+func (a *AlertConfigurationAPIService) GetAllDisabledAlertConfigsExecute(r ApiGetAllDisabledAlertConfigsRequest) (*DisabledAlertConfigsDto, *http.Response, error) {
 	var (
-		localVarHTTPMethod   = http.MethodGet
-		localVarPostBody     interface{}
-		formFiles            []formFile
-		localVarReturnValue  DisabledAlertConfigsDto[string]interface{}
+		localVarHTTPMethod  = http.MethodGet
+		localVarPostBody    interface{}
+		formFiles           []formFile
+		localVarReturnValue *DisabledAlertConfigsDto
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "AlertConfigurationAPIService.GetAllDisabledAlertConfigs")
@@ -462,14 +463,14 @@ func (a *AlertConfigurationAPIService) GetAllDisabledAlertConfigsExecute(r ApiGe
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
-			var v ApiError[string]interface{}
+			var v ApiError
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
 			}
-					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-					newErr.model = v
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
 		}
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
@@ -487,8 +488,8 @@ func (a *AlertConfigurationAPIService) GetAllDisabledAlertConfigsExecute(r ApiGe
 }
 
 type ApiGetDisabledHealthAlertConfigsRequest struct {
-	ctx context.Context
-	ApiService *AlertConfigurationAPIService
+	ctx         context.Context
+	ApiService  *AlertConfigurationAPIService
 	xScopeOrgID *string
 }
 
@@ -498,7 +499,7 @@ func (r ApiGetDisabledHealthAlertConfigsRequest) XScopeOrgID(xScopeOrgID string)
 	return r
 }
 
-func (r ApiGetDisabledHealthAlertConfigsRequest) Execute() (DisabledAlertConfigsDto[string]interface{}, *http.Response, error) {
+func (r ApiGetDisabledHealthAlertConfigsRequest) Execute() (*DisabledAlertConfigsDto, *http.Response, error) {
 	return r.ApiService.GetDisabledHealthAlertConfigsExecute(r)
 }
 
@@ -507,24 +508,25 @@ GetDisabledHealthAlertConfigs Get disabled health-based alert configurations
 
 Retrieves disabled alert configurations related to system health.
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiGetDisabledHealthAlertConfigsRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiGetDisabledHealthAlertConfigsRequest
 */
 func (a *AlertConfigurationAPIService) GetDisabledHealthAlertConfigs(ctx context.Context) ApiGetDisabledHealthAlertConfigsRequest {
 	return ApiGetDisabledHealthAlertConfigsRequest{
 		ApiService: a,
-		ctx: ctx,
+		ctx:        ctx,
 	}
 }
 
 // Execute executes the request
-//  @return DisabledAlertConfigsDto[string]interface{}
-func (a *AlertConfigurationAPIService) GetDisabledHealthAlertConfigsExecute(r ApiGetDisabledHealthAlertConfigsRequest) (DisabledAlertConfigsDto[string]interface{}, *http.Response, error) {
+//
+//	@return DisabledAlertConfigsDto
+func (a *AlertConfigurationAPIService) GetDisabledHealthAlertConfigsExecute(r ApiGetDisabledHealthAlertConfigsRequest) (*DisabledAlertConfigsDto, *http.Response, error) {
 	var (
-		localVarHTTPMethod   = http.MethodGet
-		localVarPostBody     interface{}
-		formFiles            []formFile
-		localVarReturnValue  DisabledAlertConfigsDto[string]interface{}
+		localVarHTTPMethod  = http.MethodGet
+		localVarPostBody    interface{}
+		formFiles           []formFile
+		localVarReturnValue *DisabledAlertConfigsDto
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "AlertConfigurationAPIService.GetDisabledHealthAlertConfigs")
@@ -581,14 +583,14 @@ func (a *AlertConfigurationAPIService) GetDisabledHealthAlertConfigsExecute(r Ap
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
-			var v ApiError[string]interface{}
+			var v ApiError
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
 			}
-					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-					newErr.model = v
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
 		}
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
@@ -606,8 +608,8 @@ func (a *AlertConfigurationAPIService) GetDisabledHealthAlertConfigsExecute(r Ap
 }
 
 type ApiGetDisabledRequestAlertConfigsRequest struct {
-	ctx context.Context
-	ApiService *AlertConfigurationAPIService
+	ctx         context.Context
+	ApiService  *AlertConfigurationAPIService
 	xScopeOrgID *string
 }
 
@@ -617,7 +619,7 @@ func (r ApiGetDisabledRequestAlertConfigsRequest) XScopeOrgID(xScopeOrgID string
 	return r
 }
 
-func (r ApiGetDisabledRequestAlertConfigsRequest) Execute() (DisabledAlertConfigsDto[string]interface{}, *http.Response, error) {
+func (r ApiGetDisabledRequestAlertConfigsRequest) Execute() (*DisabledAlertConfigsDto, *http.Response, error) {
 	return r.ApiService.GetDisabledRequestAlertConfigsExecute(r)
 }
 
@@ -626,24 +628,25 @@ GetDisabledRequestAlertConfigs Get disabled request-based alert configurations
 
 Retrieves disabled alert configurations specifically for requests.
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiGetDisabledRequestAlertConfigsRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiGetDisabledRequestAlertConfigsRequest
 */
 func (a *AlertConfigurationAPIService) GetDisabledRequestAlertConfigs(ctx context.Context) ApiGetDisabledRequestAlertConfigsRequest {
 	return ApiGetDisabledRequestAlertConfigsRequest{
 		ApiService: a,
-		ctx: ctx,
+		ctx:        ctx,
 	}
 }
 
 // Execute executes the request
-//  @return DisabledAlertConfigsDto[string]interface{}
-func (a *AlertConfigurationAPIService) GetDisabledRequestAlertConfigsExecute(r ApiGetDisabledRequestAlertConfigsRequest) (DisabledAlertConfigsDto[string]interface{}, *http.Response, error) {
+//
+//	@return DisabledAlertConfigsDto
+func (a *AlertConfigurationAPIService) GetDisabledRequestAlertConfigsExecute(r ApiGetDisabledRequestAlertConfigsRequest) (*DisabledAlertConfigsDto, *http.Response, error) {
 	var (
-		localVarHTTPMethod   = http.MethodGet
-		localVarPostBody     interface{}
-		formFiles            []formFile
-		localVarReturnValue  DisabledAlertConfigsDto[string]interface{}
+		localVarHTTPMethod  = http.MethodGet
+		localVarPostBody    interface{}
+		formFiles           []formFile
+		localVarReturnValue *DisabledAlertConfigsDto
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "AlertConfigurationAPIService.GetDisabledRequestAlertConfigs")
@@ -700,14 +703,14 @@ func (a *AlertConfigurationAPIService) GetDisabledRequestAlertConfigsExecute(r A
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
-			var v ApiError[string]interface{}
+			var v ApiError
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
 			}
-					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-					newErr.model = v
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
 		}
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
@@ -725,8 +728,8 @@ func (a *AlertConfigurationAPIService) GetDisabledRequestAlertConfigsExecute(r A
 }
 
 type ApiGetDisabledResourceAlertConfigsRequest struct {
-	ctx context.Context
-	ApiService *AlertConfigurationAPIService
+	ctx         context.Context
+	ApiService  *AlertConfigurationAPIService
 	xScopeOrgID *string
 }
 
@@ -736,7 +739,7 @@ func (r ApiGetDisabledResourceAlertConfigsRequest) XScopeOrgID(xScopeOrgID strin
 	return r
 }
 
-func (r ApiGetDisabledResourceAlertConfigsRequest) Execute() (DisabledAlertConfigsDto[string]interface{}, *http.Response, error) {
+func (r ApiGetDisabledResourceAlertConfigsRequest) Execute() (*DisabledAlertConfigsDto, *http.Response, error) {
 	return r.ApiService.GetDisabledResourceAlertConfigsExecute(r)
 }
 
@@ -745,24 +748,25 @@ GetDisabledResourceAlertConfigs Get disabled resource-based alert configurations
 
 Retrieves disabled alert configurations specifically for resources.
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiGetDisabledResourceAlertConfigsRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiGetDisabledResourceAlertConfigsRequest
 */
 func (a *AlertConfigurationAPIService) GetDisabledResourceAlertConfigs(ctx context.Context) ApiGetDisabledResourceAlertConfigsRequest {
 	return ApiGetDisabledResourceAlertConfigsRequest{
 		ApiService: a,
-		ctx: ctx,
+		ctx:        ctx,
 	}
 }
 
 // Execute executes the request
-//  @return DisabledAlertConfigsDto[string]interface{}
-func (a *AlertConfigurationAPIService) GetDisabledResourceAlertConfigsExecute(r ApiGetDisabledResourceAlertConfigsRequest) (DisabledAlertConfigsDto[string]interface{}, *http.Response, error) {
+//
+//	@return DisabledAlertConfigsDto
+func (a *AlertConfigurationAPIService) GetDisabledResourceAlertConfigsExecute(r ApiGetDisabledResourceAlertConfigsRequest) (*DisabledAlertConfigsDto, *http.Response, error) {
 	var (
-		localVarHTTPMethod   = http.MethodGet
-		localVarPostBody     interface{}
-		formFiles            []formFile
-		localVarReturnValue  DisabledAlertConfigsDto[string]interface{}
+		localVarHTTPMethod  = http.MethodGet
+		localVarPostBody    interface{}
+		formFiles           []formFile
+		localVarReturnValue *DisabledAlertConfigsDto
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "AlertConfigurationAPIService.GetDisabledResourceAlertConfigs")
@@ -819,14 +823,14 @@ func (a *AlertConfigurationAPIService) GetDisabledResourceAlertConfigsExecute(r 
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
-			var v ApiError[string]interface{}
+			var v ApiError
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
 			}
-					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-					newErr.model = v
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
 		}
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
@@ -844,11 +848,11 @@ func (a *AlertConfigurationAPIService) GetDisabledResourceAlertConfigsExecute(r 
 }
 
 type ApiGetFailureRuleGroupsRequest struct {
-	ctx context.Context
-	ApiService *AlertConfigurationAPIService
-	customFailureRules *string
+	ctx                  context.Context
+	ApiService           *AlertConfigurationAPIService
+	customFailureRules   *string
 	allFailureRuleGroups *string
-	xScopeOrgID *string
+	xScopeOrgID          *string
 }
 
 // Set to true to fetch only custom failure rules
@@ -869,7 +873,7 @@ func (r ApiGetFailureRuleGroupsRequest) XScopeOrgID(xScopeOrgID string) ApiGetFa
 	return r
 }
 
-func (r ApiGetFailureRuleGroupsRequest) Execute() (PrometheusRuleGroupDto[string]interface{}, *http.Response, error) {
+func (r ApiGetFailureRuleGroupsRequest) Execute() (*PrometheusRuleGroupDto, *http.Response, error) {
 	return r.ApiService.GetFailureRuleGroupsExecute(r)
 }
 
@@ -878,24 +882,25 @@ GetFailureRuleGroups Get Prometheus failure rule groups
 
 Retrieves Prometheus rule groups related to failures. Can be filtered for custom or all rules.
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiGetFailureRuleGroupsRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiGetFailureRuleGroupsRequest
 */
 func (a *AlertConfigurationAPIService) GetFailureRuleGroups(ctx context.Context) ApiGetFailureRuleGroupsRequest {
 	return ApiGetFailureRuleGroupsRequest{
 		ApiService: a,
-		ctx: ctx,
+		ctx:        ctx,
 	}
 }
 
 // Execute executes the request
-//  @return PrometheusRuleGroupDto[string]interface{}
-func (a *AlertConfigurationAPIService) GetFailureRuleGroupsExecute(r ApiGetFailureRuleGroupsRequest) (PrometheusRuleGroupDto[string]interface{}, *http.Response, error) {
+//
+//	@return PrometheusRuleGroupDto
+func (a *AlertConfigurationAPIService) GetFailureRuleGroupsExecute(r ApiGetFailureRuleGroupsRequest) (*PrometheusRuleGroupDto, *http.Response, error) {
 	var (
-		localVarHTTPMethod   = http.MethodGet
-		localVarPostBody     interface{}
-		formFiles            []formFile
-		localVarReturnValue  PrometheusRuleGroupDto[string]interface{}
+		localVarHTTPMethod  = http.MethodGet
+		localVarPostBody    interface{}
+		formFiles           []formFile
+		localVarReturnValue *PrometheusRuleGroupDto
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "AlertConfigurationAPIService.GetFailureRuleGroups")
@@ -964,14 +969,14 @@ func (a *AlertConfigurationAPIService) GetFailureRuleGroupsExecute(r ApiGetFailu
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
-			var v ApiError[string]interface{}
+			var v ApiError
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
 			}
-					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-					newErr.model = v
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
 		}
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
@@ -989,8 +994,8 @@ func (a *AlertConfigurationAPIService) GetFailureRuleGroupsExecute(r ApiGetFailu
 }
 
 type ApiGetHealthAlertConfigsRequest struct {
-	ctx context.Context
-	ApiService *AlertConfigurationAPIService
+	ctx         context.Context
+	ApiService  *AlertConfigurationAPIService
 	xScopeOrgID *string
 }
 
@@ -1000,7 +1005,7 @@ func (r ApiGetHealthAlertConfigsRequest) XScopeOrgID(xScopeOrgID string) ApiGetH
 	return r
 }
 
-func (r ApiGetHealthAlertConfigsRequest) Execute() (AlertConfigsDto[string]interface{}, *http.Response, error) {
+func (r ApiGetHealthAlertConfigsRequest) Execute() (*AlertConfigsDto, *http.Response, error) {
 	return r.ApiService.GetHealthAlertConfigsExecute(r)
 }
 
@@ -1009,24 +1014,25 @@ GetHealthAlertConfigs Get health-based alert configurations
 
 Retrieves alert configurations related to system health.
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiGetHealthAlertConfigsRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiGetHealthAlertConfigsRequest
 */
 func (a *AlertConfigurationAPIService) GetHealthAlertConfigs(ctx context.Context) ApiGetHealthAlertConfigsRequest {
 	return ApiGetHealthAlertConfigsRequest{
 		ApiService: a,
-		ctx: ctx,
+		ctx:        ctx,
 	}
 }
 
 // Execute executes the request
-//  @return AlertConfigsDto[string]interface{}
-func (a *AlertConfigurationAPIService) GetHealthAlertConfigsExecute(r ApiGetHealthAlertConfigsRequest) (AlertConfigsDto[string]interface{}, *http.Response, error) {
+//
+//	@return AlertConfigsDto
+func (a *AlertConfigurationAPIService) GetHealthAlertConfigsExecute(r ApiGetHealthAlertConfigsRequest) (*AlertConfigsDto, *http.Response, error) {
 	var (
-		localVarHTTPMethod   = http.MethodGet
-		localVarPostBody     interface{}
-		formFiles            []formFile
-		localVarReturnValue  AlertConfigsDto[string]interface{}
+		localVarHTTPMethod  = http.MethodGet
+		localVarPostBody    interface{}
+		formFiles           []formFile
+		localVarReturnValue *AlertConfigsDto
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "AlertConfigurationAPIService.GetHealthAlertConfigs")
@@ -1083,14 +1089,14 @@ func (a *AlertConfigurationAPIService) GetHealthAlertConfigsExecute(r ApiGetHeal
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
-			var v ApiError[string]interface{}
+			var v ApiError
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
 			}
-					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-					newErr.model = v
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
 		}
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
@@ -1108,8 +1114,8 @@ func (a *AlertConfigurationAPIService) GetHealthAlertConfigsExecute(r ApiGetHeal
 }
 
 type ApiGetRequestAlertConfigsRequest struct {
-	ctx context.Context
-	ApiService *AlertConfigurationAPIService
+	ctx         context.Context
+	ApiService  *AlertConfigurationAPIService
 	xScopeOrgID *string
 }
 
@@ -1119,7 +1125,7 @@ func (r ApiGetRequestAlertConfigsRequest) XScopeOrgID(xScopeOrgID string) ApiGet
 	return r
 }
 
-func (r ApiGetRequestAlertConfigsRequest) Execute() (AlertConfigsDto[string]interface{}, *http.Response, error) {
+func (r ApiGetRequestAlertConfigsRequest) Execute() (*AlertConfigsDto, *http.Response, error) {
 	return r.ApiService.GetRequestAlertConfigsExecute(r)
 }
 
@@ -1128,24 +1134,25 @@ GetRequestAlertConfigs Get request-based alert configurations
 
 Retrieves alert configurations specifically for requests.
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiGetRequestAlertConfigsRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiGetRequestAlertConfigsRequest
 */
 func (a *AlertConfigurationAPIService) GetRequestAlertConfigs(ctx context.Context) ApiGetRequestAlertConfigsRequest {
 	return ApiGetRequestAlertConfigsRequest{
 		ApiService: a,
-		ctx: ctx,
+		ctx:        ctx,
 	}
 }
 
 // Execute executes the request
-//  @return AlertConfigsDto[string]interface{}
-func (a *AlertConfigurationAPIService) GetRequestAlertConfigsExecute(r ApiGetRequestAlertConfigsRequest) (AlertConfigsDto[string]interface{}, *http.Response, error) {
+//
+//	@return AlertConfigsDto
+func (a *AlertConfigurationAPIService) GetRequestAlertConfigsExecute(r ApiGetRequestAlertConfigsRequest) (*AlertConfigsDto, *http.Response, error) {
 	var (
-		localVarHTTPMethod   = http.MethodGet
-		localVarPostBody     interface{}
-		formFiles            []formFile
-		localVarReturnValue  AlertConfigsDto[string]interface{}
+		localVarHTTPMethod  = http.MethodGet
+		localVarPostBody    interface{}
+		formFiles           []formFile
+		localVarReturnValue *AlertConfigsDto
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "AlertConfigurationAPIService.GetRequestAlertConfigs")
@@ -1202,14 +1209,14 @@ func (a *AlertConfigurationAPIService) GetRequestAlertConfigsExecute(r ApiGetReq
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
-			var v ApiError[string]interface{}
+			var v ApiError
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
 			}
-					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-					newErr.model = v
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
 		}
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
@@ -1227,8 +1234,8 @@ func (a *AlertConfigurationAPIService) GetRequestAlertConfigsExecute(r ApiGetReq
 }
 
 type ApiGetResourceAlertConfigsRequest struct {
-	ctx context.Context
-	ApiService *AlertConfigurationAPIService
+	ctx         context.Context
+	ApiService  *AlertConfigurationAPIService
 	xScopeOrgID *string
 }
 
@@ -1238,7 +1245,7 @@ func (r ApiGetResourceAlertConfigsRequest) XScopeOrgID(xScopeOrgID string) ApiGe
 	return r
 }
 
-func (r ApiGetResourceAlertConfigsRequest) Execute() (AlertConfigsDto[string]interface{}, *http.Response, error) {
+func (r ApiGetResourceAlertConfigsRequest) Execute() (*AlertConfigsDto, *http.Response, error) {
 	return r.ApiService.GetResourceAlertConfigsExecute(r)
 }
 
@@ -1247,24 +1254,25 @@ GetResourceAlertConfigs Get resource-based alert configurations
 
 Retrieves alert configurations specifically for resources.
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiGetResourceAlertConfigsRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiGetResourceAlertConfigsRequest
 */
 func (a *AlertConfigurationAPIService) GetResourceAlertConfigs(ctx context.Context) ApiGetResourceAlertConfigsRequest {
 	return ApiGetResourceAlertConfigsRequest{
 		ApiService: a,
-		ctx: ctx,
+		ctx:        ctx,
 	}
 }
 
 // Execute executes the request
-//  @return AlertConfigsDto[string]interface{}
-func (a *AlertConfigurationAPIService) GetResourceAlertConfigsExecute(r ApiGetResourceAlertConfigsRequest) (AlertConfigsDto[string]interface{}, *http.Response, error) {
+//
+//	@return AlertConfigsDto
+func (a *AlertConfigurationAPIService) GetResourceAlertConfigsExecute(r ApiGetResourceAlertConfigsRequest) (*AlertConfigsDto, *http.Response, error) {
 	var (
-		localVarHTTPMethod   = http.MethodGet
-		localVarPostBody     interface{}
-		formFiles            []formFile
-		localVarReturnValue  AlertConfigsDto[string]interface{}
+		localVarHTTPMethod  = http.MethodGet
+		localVarPostBody    interface{}
+		formFiles           []formFile
+		localVarReturnValue *AlertConfigsDto
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "AlertConfigurationAPIService.GetResourceAlertConfigs")
@@ -1321,14 +1329,14 @@ func (a *AlertConfigurationAPIService) GetResourceAlertConfigsExecute(r ApiGetRe
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
-			var v ApiError[string]interface{}
+			var v ApiError
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
 			}
-					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-					newErr.model = v
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
 		}
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
@@ -1346,8 +1354,8 @@ func (a *AlertConfigurationAPIService) GetResourceAlertConfigsExecute(r ApiGetRe
 }
 
 type ApiGetSloAlertConfigsRequest struct {
-	ctx context.Context
-	ApiService *AlertConfigurationAPIService
+	ctx         context.Context
+	ApiService  *AlertConfigurationAPIService
 	xScopeOrgID *string
 }
 
@@ -1357,7 +1365,7 @@ func (r ApiGetSloAlertConfigsRequest) XScopeOrgID(xScopeOrgID string) ApiGetSloA
 	return r
 }
 
-func (r ApiGetSloAlertConfigsRequest) Execute() (AlertConfigsDto[string]interface{}, *http.Response, error) {
+func (r ApiGetSloAlertConfigsRequest) Execute() (*AlertConfigsDto, *http.Response, error) {
 	return r.ApiService.GetSloAlertConfigsExecute(r)
 }
 
@@ -1366,24 +1374,25 @@ GetSloAlertConfigs Get SLO-based alert configurations
 
 Retrieves alert configurations related to Service Level Objectives.
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiGetSloAlertConfigsRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiGetSloAlertConfigsRequest
 */
 func (a *AlertConfigurationAPIService) GetSloAlertConfigs(ctx context.Context) ApiGetSloAlertConfigsRequest {
 	return ApiGetSloAlertConfigsRequest{
 		ApiService: a,
-		ctx: ctx,
+		ctx:        ctx,
 	}
 }
 
 // Execute executes the request
-//  @return AlertConfigsDto[string]interface{}
-func (a *AlertConfigurationAPIService) GetSloAlertConfigsExecute(r ApiGetSloAlertConfigsRequest) (AlertConfigsDto[string]interface{}, *http.Response, error) {
+//
+//	@return AlertConfigsDto
+func (a *AlertConfigurationAPIService) GetSloAlertConfigsExecute(r ApiGetSloAlertConfigsRequest) (*AlertConfigsDto, *http.Response, error) {
 	var (
-		localVarHTTPMethod   = http.MethodGet
-		localVarPostBody     interface{}
-		formFiles            []formFile
-		localVarReturnValue  AlertConfigsDto[string]interface{}
+		localVarHTTPMethod  = http.MethodGet
+		localVarPostBody    interface{}
+		formFiles           []formFile
+		localVarReturnValue *AlertConfigsDto
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "AlertConfigurationAPIService.GetSloAlertConfigs")
@@ -1440,14 +1449,14 @@ func (a *AlertConfigurationAPIService) GetSloAlertConfigsExecute(r ApiGetSloAler
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
-			var v ApiError[string]interface{}
+			var v ApiError
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
 			}
-					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-					newErr.model = v
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
 		}
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
@@ -1465,10 +1474,10 @@ func (a *AlertConfigurationAPIService) GetSloAlertConfigsExecute(r ApiGetSloAler
 }
 
 type ApiPutAlertConfigRequest struct {
-	ctx context.Context
-	ApiService *AlertConfigurationAPIService
+	ctx            context.Context
+	ApiService     *AlertConfigurationAPIService
 	alertConfigDto *AlertConfigDto
-	xScopeOrgID *string
+	xScopeOrgID    *string
 }
 
 func (r ApiPutAlertConfigRequest) AlertConfigDto(alertConfigDto AlertConfigDto) ApiPutAlertConfigRequest {
@@ -1491,22 +1500,22 @@ PutAlertConfig Create or update a single alert configuration
 
 Creates a new alert configuration or updates an existing one based on the provided data.
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiPutAlertConfigRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiPutAlertConfigRequest
 */
 func (a *AlertConfigurationAPIService) PutAlertConfig(ctx context.Context) ApiPutAlertConfigRequest {
 	return ApiPutAlertConfigRequest{
 		ApiService: a,
-		ctx: ctx,
+		ctx:        ctx,
 	}
 }
 
 // Execute executes the request
 func (a *AlertConfigurationAPIService) PutAlertConfigExecute(r ApiPutAlertConfigRequest) (*http.Response, error) {
 	var (
-		localVarHTTPMethod   = http.MethodPost
-		localVarPostBody     interface{}
-		formFiles            []formFile
+		localVarHTTPMethod = http.MethodPost
+		localVarPostBody   interface{}
+		formFiles          []formFile
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "AlertConfigurationAPIService.PutAlertConfig")
@@ -1568,25 +1577,25 @@ func (a *AlertConfigurationAPIService) PutAlertConfigExecute(r ApiPutAlertConfig
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 422 {
-			var v ApiError[string]interface{}
+			var v ApiError
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarHTTPResponse, newErr
 			}
-					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-					newErr.model = v
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
 			return localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
-			var v ApiError[string]interface{}
+			var v ApiError
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarHTTPResponse, newErr
 			}
-					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-					newErr.model = v
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
 		}
 		return localVarHTTPResponse, newErr
 	}
@@ -1595,10 +1604,10 @@ func (a *AlertConfigurationAPIService) PutAlertConfigExecute(r ApiPutAlertConfig
 }
 
 type ApiPutAlertConfigsRequest struct {
-	ctx context.Context
-	ApiService *AlertConfigurationAPIService
+	ctx             context.Context
+	ApiService      *AlertConfigurationAPIService
 	alertConfigsDto *AlertConfigsDto
-	xScopeOrgID *string
+	xScopeOrgID     *string
 }
 
 func (r ApiPutAlertConfigsRequest) AlertConfigsDto(alertConfigsDto AlertConfigsDto) ApiPutAlertConfigsRequest {
@@ -1621,22 +1630,22 @@ PutAlertConfigs Create or update multiple alert configurations
 
 Creates or updates a batch of alert configurations.
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiPutAlertConfigsRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiPutAlertConfigsRequest
 */
 func (a *AlertConfigurationAPIService) PutAlertConfigs(ctx context.Context) ApiPutAlertConfigsRequest {
 	return ApiPutAlertConfigsRequest{
 		ApiService: a,
-		ctx: ctx,
+		ctx:        ctx,
 	}
 }
 
 // Execute executes the request
 func (a *AlertConfigurationAPIService) PutAlertConfigsExecute(r ApiPutAlertConfigsRequest) (*http.Response, error) {
 	var (
-		localVarHTTPMethod   = http.MethodPost
-		localVarPostBody     interface{}
-		formFiles            []formFile
+		localVarHTTPMethod = http.MethodPost
+		localVarPostBody   interface{}
+		formFiles          []formFile
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "AlertConfigurationAPIService.PutAlertConfigs")
@@ -1698,25 +1707,25 @@ func (a *AlertConfigurationAPIService) PutAlertConfigsExecute(r ApiPutAlertConfi
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 422 {
-			var v ApiError[string]interface{}
+			var v ApiError
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarHTTPResponse, newErr
 			}
-					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-					newErr.model = v
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
 			return localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
-			var v ApiError[string]interface{}
+			var v ApiError
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarHTTPResponse, newErr
 			}
-					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-					newErr.model = v
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
 		}
 		return localVarHTTPResponse, newErr
 	}
@@ -1725,10 +1734,10 @@ func (a *AlertConfigurationAPIService) PutAlertConfigsExecute(r ApiPutAlertConfi
 }
 
 type ApiPutDisabledAlertConfigRequest struct {
-	ctx context.Context
-	ApiService *AlertConfigurationAPIService
+	ctx                    context.Context
+	ApiService             *AlertConfigurationAPIService
 	disabledAlertConfigDto *DisabledAlertConfigDto
-	xScopeOrgID *string
+	xScopeOrgID            *string
 }
 
 func (r ApiPutDisabledAlertConfigRequest) DisabledAlertConfigDto(disabledAlertConfigDto DisabledAlertConfigDto) ApiPutDisabledAlertConfigRequest {
@@ -1751,22 +1760,22 @@ PutDisabledAlertConfig Disable a single alert configuration
 
 Creates a new disabled alert configuration, effectively silencing it.
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiPutDisabledAlertConfigRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiPutDisabledAlertConfigRequest
 */
 func (a *AlertConfigurationAPIService) PutDisabledAlertConfig(ctx context.Context) ApiPutDisabledAlertConfigRequest {
 	return ApiPutDisabledAlertConfigRequest{
 		ApiService: a,
-		ctx: ctx,
+		ctx:        ctx,
 	}
 }
 
 // Execute executes the request
 func (a *AlertConfigurationAPIService) PutDisabledAlertConfigExecute(r ApiPutDisabledAlertConfigRequest) (*http.Response, error) {
 	var (
-		localVarHTTPMethod   = http.MethodPost
-		localVarPostBody     interface{}
-		formFiles            []formFile
+		localVarHTTPMethod = http.MethodPost
+		localVarPostBody   interface{}
+		formFiles          []formFile
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "AlertConfigurationAPIService.PutDisabledAlertConfig")
@@ -1828,25 +1837,25 @@ func (a *AlertConfigurationAPIService) PutDisabledAlertConfigExecute(r ApiPutDis
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 422 {
-			var v ApiError[string]interface{}
+			var v ApiError
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarHTTPResponse, newErr
 			}
-					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-					newErr.model = v
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
 			return localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
-			var v ApiError[string]interface{}
+			var v ApiError
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarHTTPResponse, newErr
 			}
-					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-					newErr.model = v
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
 		}
 		return localVarHTTPResponse, newErr
 	}
@@ -1855,10 +1864,10 @@ func (a *AlertConfigurationAPIService) PutDisabledAlertConfigExecute(r ApiPutDis
 }
 
 type ApiPutDisabledAlertConfigsRequest struct {
-	ctx context.Context
-	ApiService *AlertConfigurationAPIService
+	ctx                     context.Context
+	ApiService              *AlertConfigurationAPIService
 	disabledAlertConfigsDto *DisabledAlertConfigsDto
-	xScopeOrgID *string
+	xScopeOrgID             *string
 }
 
 func (r ApiPutDisabledAlertConfigsRequest) DisabledAlertConfigsDto(disabledAlertConfigsDto DisabledAlertConfigsDto) ApiPutDisabledAlertConfigsRequest {
@@ -1881,22 +1890,22 @@ PutDisabledAlertConfigs Disable multiple alert configurations
 
 Creates or updates a batch of disabled alert configurations.
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiPutDisabledAlertConfigsRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiPutDisabledAlertConfigsRequest
 */
 func (a *AlertConfigurationAPIService) PutDisabledAlertConfigs(ctx context.Context) ApiPutDisabledAlertConfigsRequest {
 	return ApiPutDisabledAlertConfigsRequest{
 		ApiService: a,
-		ctx: ctx,
+		ctx:        ctx,
 	}
 }
 
 // Execute executes the request
 func (a *AlertConfigurationAPIService) PutDisabledAlertConfigsExecute(r ApiPutDisabledAlertConfigsRequest) (*http.Response, error) {
 	var (
-		localVarHTTPMethod   = http.MethodPost
-		localVarPostBody     interface{}
-		formFiles            []formFile
+		localVarHTTPMethod = http.MethodPost
+		localVarPostBody   interface{}
+		formFiles          []formFile
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "AlertConfigurationAPIService.PutDisabledAlertConfigs")
@@ -1958,25 +1967,25 @@ func (a *AlertConfigurationAPIService) PutDisabledAlertConfigsExecute(r ApiPutDi
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 422 {
-			var v ApiError[string]interface{}
+			var v ApiError
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarHTTPResponse, newErr
 			}
-					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-					newErr.model = v
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
 			return localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
-			var v ApiError[string]interface{}
+			var v ApiError
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarHTTPResponse, newErr
 			}
-					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-					newErr.model = v
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
 		}
 		return localVarHTTPResponse, newErr
 	}
@@ -1985,10 +1994,10 @@ func (a *AlertConfigurationAPIService) PutDisabledAlertConfigsExecute(r ApiPutDi
 }
 
 type ApiValidateDisabledAlertConfigRequest struct {
-	ctx context.Context
-	ApiService *AlertConfigurationAPIService
+	ctx                    context.Context
+	ApiService             *AlertConfigurationAPIService
 	disabledAlertConfigDto *DisabledAlertConfigDto
-	xScopeOrgID *string
+	xScopeOrgID            *string
 }
 
 func (r ApiValidateDisabledAlertConfigRequest) DisabledAlertConfigDto(disabledAlertConfigDto DisabledAlertConfigDto) ApiValidateDisabledAlertConfigRequest {
@@ -2011,22 +2020,22 @@ ValidateDisabledAlertConfig Validate a single disabled alert configuration
 
 Validates a single disabled alert configuration without persisting it. Returns 200 if valid, 422 with error details if invalid.
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiValidateDisabledAlertConfigRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiValidateDisabledAlertConfigRequest
 */
 func (a *AlertConfigurationAPIService) ValidateDisabledAlertConfig(ctx context.Context) ApiValidateDisabledAlertConfigRequest {
 	return ApiValidateDisabledAlertConfigRequest{
 		ApiService: a,
-		ctx: ctx,
+		ctx:        ctx,
 	}
 }
 
 // Execute executes the request
 func (a *AlertConfigurationAPIService) ValidateDisabledAlertConfigExecute(r ApiValidateDisabledAlertConfigRequest) (*http.Response, error) {
 	var (
-		localVarHTTPMethod   = http.MethodPost
-		localVarPostBody     interface{}
-		formFiles            []formFile
+		localVarHTTPMethod = http.MethodPost
+		localVarPostBody   interface{}
+		formFiles          []formFile
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "AlertConfigurationAPIService.ValidateDisabledAlertConfig")
@@ -2088,14 +2097,14 @@ func (a *AlertConfigurationAPIService) ValidateDisabledAlertConfigExecute(r ApiV
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 422 {
-			var v ApiError[string]interface{}
+			var v ApiError
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarHTTPResponse, newErr
 			}
-					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-					newErr.model = v
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
 		}
 		return localVarHTTPResponse, newErr
 	}
@@ -2104,10 +2113,10 @@ func (a *AlertConfigurationAPIService) ValidateDisabledAlertConfigExecute(r ApiV
 }
 
 type ApiValidateDisabledAlertConfigsRequest struct {
-	ctx context.Context
-	ApiService *AlertConfigurationAPIService
+	ctx                     context.Context
+	ApiService              *AlertConfigurationAPIService
 	disabledAlertConfigsDto *DisabledAlertConfigsDto
-	xScopeOrgID *string
+	xScopeOrgID             *string
 }
 
 func (r ApiValidateDisabledAlertConfigsRequest) DisabledAlertConfigsDto(disabledAlertConfigsDto DisabledAlertConfigsDto) ApiValidateDisabledAlertConfigsRequest {
@@ -2130,22 +2139,22 @@ ValidateDisabledAlertConfigs Validate disabled alert configurations
 
 Validates a batch of disabled alert configurations without persisting them. Returns 200 if valid, 422 with error details if invalid.
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiValidateDisabledAlertConfigsRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiValidateDisabledAlertConfigsRequest
 */
 func (a *AlertConfigurationAPIService) ValidateDisabledAlertConfigs(ctx context.Context) ApiValidateDisabledAlertConfigsRequest {
 	return ApiValidateDisabledAlertConfigsRequest{
 		ApiService: a,
-		ctx: ctx,
+		ctx:        ctx,
 	}
 }
 
 // Execute executes the request
 func (a *AlertConfigurationAPIService) ValidateDisabledAlertConfigsExecute(r ApiValidateDisabledAlertConfigsRequest) (*http.Response, error) {
 	var (
-		localVarHTTPMethod   = http.MethodPost
-		localVarPostBody     interface{}
-		formFiles            []formFile
+		localVarHTTPMethod = http.MethodPost
+		localVarPostBody   interface{}
+		formFiles          []formFile
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "AlertConfigurationAPIService.ValidateDisabledAlertConfigs")
@@ -2207,14 +2216,14 @@ func (a *AlertConfigurationAPIService) ValidateDisabledAlertConfigsExecute(r Api
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 422 {
-			var v ApiError[string]interface{}
+			var v ApiError
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarHTTPResponse, newErr
 			}
-					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-					newErr.model = v
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
 		}
 		return localVarHTTPResponse, newErr
 	}

--- a/go/gcom/api_log_drilldown_config_controller.go
+++ b/go/gcom/api_log_drilldown_config_controller.go
@@ -20,14 +20,13 @@ import (
 	"strings"
 )
 
-
 // LogDrilldownConfigControllerAPIService LogDrilldownConfigControllerAPI service
 type LogDrilldownConfigControllerAPIService service
 
 type ApiDeleteConfig3Request struct {
-	ctx context.Context
-	ApiService *LogDrilldownConfigControllerAPIService
-	name string
+	ctx         context.Context
+	ApiService  *LogDrilldownConfigControllerAPIService
+	name        string
 	xScopeOrgID *string
 }
 
@@ -46,24 +45,24 @@ DeleteConfig3 Delete log drilldown configuration
 
 Deletes the specified log drilldown configuration entry for the tenant
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param name Name of the log configuration to delete
- @return ApiDeleteConfig3Request
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param name Name of the log configuration to delete
+	@return ApiDeleteConfig3Request
 */
 func (a *LogDrilldownConfigControllerAPIService) DeleteConfig3(ctx context.Context, name string) ApiDeleteConfig3Request {
 	return ApiDeleteConfig3Request{
 		ApiService: a,
-		ctx: ctx,
-		name: name,
+		ctx:        ctx,
+		name:       name,
 	}
 }
 
 // Execute executes the request
 func (a *LogDrilldownConfigControllerAPIService) DeleteConfig3Execute(r ApiDeleteConfig3Request) (*http.Response, error) {
 	var (
-		localVarHTTPMethod   = http.MethodDelete
-		localVarPostBody     interface{}
-		formFiles            []formFile
+		localVarHTTPMethod = http.MethodDelete
+		localVarPostBody   interface{}
+		formFiles          []formFile
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "LogDrilldownConfigControllerAPIService.DeleteConfig3")
@@ -127,8 +126,8 @@ func (a *LogDrilldownConfigControllerAPIService) DeleteConfig3Execute(r ApiDelet
 }
 
 type ApiGetTenantLogConfigRequest struct {
-	ctx context.Context
-	ApiService *LogDrilldownConfigControllerAPIService
+	ctx         context.Context
+	ApiService  *LogDrilldownConfigControllerAPIService
 	xScopeOrgID *string
 }
 
@@ -138,7 +137,7 @@ func (r ApiGetTenantLogConfigRequest) XScopeOrgID(xScopeOrgID string) ApiGetTena
 	return r
 }
 
-func (r ApiGetTenantLogConfigRequest) Execute() (TenantLogConfigResponseDto[string]interface{}, *http.Response, error) {
+func (r ApiGetTenantLogConfigRequest) Execute() (*TenantLogConfigResponseDto, *http.Response, error) {
 	return r.ApiService.GetTenantLogConfigExecute(r)
 }
 
@@ -147,24 +146,25 @@ GetTenantLogConfig Get tenant log configuration
 
 Retrieves all the log drilldown configuration entries for the tenant
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiGetTenantLogConfigRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiGetTenantLogConfigRequest
 */
 func (a *LogDrilldownConfigControllerAPIService) GetTenantLogConfig(ctx context.Context) ApiGetTenantLogConfigRequest {
 	return ApiGetTenantLogConfigRequest{
 		ApiService: a,
-		ctx: ctx,
+		ctx:        ctx,
 	}
 }
 
 // Execute executes the request
-//  @return TenantLogConfigResponseDto[string]interface{}
-func (a *LogDrilldownConfigControllerAPIService) GetTenantLogConfigExecute(r ApiGetTenantLogConfigRequest) (TenantLogConfigResponseDto[string]interface{}, *http.Response, error) {
+//
+//	@return TenantLogConfigResponseDto
+func (a *LogDrilldownConfigControllerAPIService) GetTenantLogConfigExecute(r ApiGetTenantLogConfigRequest) (*TenantLogConfigResponseDto, *http.Response, error) {
 	var (
-		localVarHTTPMethod   = http.MethodGet
-		localVarPostBody     interface{}
-		formFiles            []formFile
-		localVarReturnValue  TenantLogConfigResponseDto[string]interface{}
+		localVarHTTPMethod  = http.MethodGet
+		localVarPostBody    interface{}
+		formFiles           []formFile
+		localVarReturnValue *TenantLogConfigResponseDto
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "LogDrilldownConfigControllerAPIService.GetTenantLogConfig")
@@ -236,9 +236,9 @@ func (a *LogDrilldownConfigControllerAPIService) GetTenantLogConfigExecute(r Api
 }
 
 type ApiReorderLogConfigPrioritiesRequest struct {
-	ctx context.Context
-	ApiService *LogDrilldownConfigControllerAPIService
-	body *string
+	ctx         context.Context
+	ApiService  *LogDrilldownConfigControllerAPIService
+	body        *string
 	xScopeOrgID *string
 }
 
@@ -262,24 +262,25 @@ ReorderLogConfigPriorities Reorder log drilldown configuration priorities
 
 Accepts a list of log drilldown configuration names and their new priorities to reorder the configurations for the tenant
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiReorderLogConfigPrioritiesRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiReorderLogConfigPrioritiesRequest
 */
 func (a *LogDrilldownConfigControllerAPIService) ReorderLogConfigPriorities(ctx context.Context) ApiReorderLogConfigPrioritiesRequest {
 	return ApiReorderLogConfigPrioritiesRequest{
 		ApiService: a,
-		ctx: ctx,
+		ctx:        ctx,
 	}
 }
 
 // Execute executes the request
-//  @return TenantLogConfigResponseDto
+//
+//	@return TenantLogConfigResponseDto
 func (a *LogDrilldownConfigControllerAPIService) ReorderLogConfigPrioritiesExecute(r ApiReorderLogConfigPrioritiesRequest) (*TenantLogConfigResponseDto, *http.Response, error) {
 	var (
-		localVarHTTPMethod   = http.MethodPut
-		localVarPostBody     interface{}
-		formFiles            []formFile
-		localVarReturnValue  *TenantLogConfigResponseDto
+		localVarHTTPMethod  = http.MethodPut
+		localVarPostBody    interface{}
+		formFiles           []formFile
+		localVarReturnValue *TenantLogConfigResponseDto
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "LogDrilldownConfigControllerAPIService.ReorderLogConfigPriorities")
@@ -341,14 +342,14 @@ func (a *LogDrilldownConfigControllerAPIService) ReorderLogConfigPrioritiesExecu
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 422 {
-			var v ApiError[string]interface{}
+			var v ApiError
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
 			}
-					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-					newErr.model = v
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
 		}
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
@@ -366,9 +367,9 @@ func (a *LogDrilldownConfigControllerAPIService) ReorderLogConfigPrioritiesExecu
 }
 
 type ApiUpsertLogDrilldownConfigRequest struct {
-	ctx context.Context
-	ApiService *LogDrilldownConfigControllerAPIService
-	body *string
+	ctx         context.Context
+	ApiService  *LogDrilldownConfigControllerAPIService
+	body        *string
 	xScopeOrgID *string
 }
 
@@ -392,22 +393,22 @@ UpsertLogDrilldownConfig Upsert log drilldown configuration
 
 Creates or updates the log drilldown configuration entry for the tenant
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiUpsertLogDrilldownConfigRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiUpsertLogDrilldownConfigRequest
 */
 func (a *LogDrilldownConfigControllerAPIService) UpsertLogDrilldownConfig(ctx context.Context) ApiUpsertLogDrilldownConfigRequest {
 	return ApiUpsertLogDrilldownConfigRequest{
 		ApiService: a,
-		ctx: ctx,
+		ctx:        ctx,
 	}
 }
 
 // Execute executes the request
 func (a *LogDrilldownConfigControllerAPIService) UpsertLogDrilldownConfigExecute(r ApiUpsertLogDrilldownConfigRequest) (*http.Response, error) {
 	var (
-		localVarHTTPMethod   = http.MethodPost
-		localVarPostBody     interface{}
-		formFiles            []formFile
+		localVarHTTPMethod = http.MethodPost
+		localVarPostBody   interface{}
+		formFiles          []formFile
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "LogDrilldownConfigControllerAPIService.UpsertLogDrilldownConfig")
@@ -469,14 +470,14 @@ func (a *LogDrilldownConfigControllerAPIService) UpsertLogDrilldownConfigExecute
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 422 {
-			var v ApiError[string]interface{}
+			var v ApiError
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarHTTPResponse, newErr
 			}
-					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-					newErr.model = v
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
 		}
 		return localVarHTTPResponse, newErr
 	}

--- a/go/gcom/api_model_rules_configuration.go
+++ b/go/gcom/api_model_rules_configuration.go
@@ -20,14 +20,13 @@ import (
 	"strings"
 )
 
-
 // ModelRulesConfigurationAPIService ModelRulesConfigurationAPI service
 type ModelRulesConfigurationAPIService service
 
 type ApiDeleteModelRulesRequest struct {
-	ctx context.Context
-	ApiService *ModelRulesConfigurationAPIService
-	name string
+	ctx         context.Context
+	ApiService  *ModelRulesConfigurationAPIService
+	name        string
 	xScopeOrgID *string
 }
 
@@ -46,24 +45,24 @@ DeleteModelRules Delete custom model rules by name
 
 Permanently deletes a specific custom model rules configuration by its name.
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param name The name of the model rules configuration to delete
- @return ApiDeleteModelRulesRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param name The name of the model rules configuration to delete
+	@return ApiDeleteModelRulesRequest
 */
 func (a *ModelRulesConfigurationAPIService) DeleteModelRules(ctx context.Context, name string) ApiDeleteModelRulesRequest {
 	return ApiDeleteModelRulesRequest{
 		ApiService: a,
-		ctx: ctx,
-		name: name,
+		ctx:        ctx,
+		name:       name,
 	}
 }
 
 // Execute executes the request
 func (a *ModelRulesConfigurationAPIService) DeleteModelRulesExecute(r ApiDeleteModelRulesRequest) (*http.Response, error) {
 	var (
-		localVarHTTPMethod   = http.MethodDelete
-		localVarPostBody     interface{}
-		formFiles            []formFile
+		localVarHTTPMethod = http.MethodDelete
+		localVarPostBody   interface{}
+		formFiles          []formFile
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ModelRulesConfigurationAPIService.DeleteModelRules")
@@ -127,9 +126,9 @@ func (a *ModelRulesConfigurationAPIService) DeleteModelRulesExecute(r ApiDeleteM
 }
 
 type ApiGetModelRulesRequest struct {
-	ctx context.Context
-	ApiService *ModelRulesConfigurationAPIService
-	name string
+	ctx         context.Context
+	ApiService  *ModelRulesConfigurationAPIService
+	name        string
 	xScopeOrgID *string
 }
 
@@ -148,26 +147,27 @@ GetModelRules Get custom model rules by name
 
 Retrieves a specific custom model rules configuration by its name.
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param name The name of the model rules configuration to retrieve
- @return ApiGetModelRulesRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param name The name of the model rules configuration to retrieve
+	@return ApiGetModelRulesRequest
 */
 func (a *ModelRulesConfigurationAPIService) GetModelRules(ctx context.Context, name string) ApiGetModelRulesRequest {
 	return ApiGetModelRulesRequest{
 		ApiService: a,
-		ctx: ctx,
-		name: name,
+		ctx:        ctx,
+		name:       name,
 	}
 }
 
 // Execute executes the request
-//  @return ModelRulesDto
+//
+//	@return ModelRulesDto
 func (a *ModelRulesConfigurationAPIService) GetModelRulesExecute(r ApiGetModelRulesRequest) (*ModelRulesDto, *http.Response, error) {
 	var (
-		localVarHTTPMethod   = http.MethodGet
-		localVarPostBody     interface{}
-		formFiles            []formFile
-		localVarReturnValue  *ModelRulesDto
+		localVarHTTPMethod  = http.MethodGet
+		localVarPostBody    interface{}
+		formFiles           []formFile
+		localVarReturnValue *ModelRulesDto
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ModelRulesConfigurationAPIService.GetModelRules")
@@ -231,8 +231,8 @@ func (a *ModelRulesConfigurationAPIService) GetModelRulesExecute(r ApiGetModelRu
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
 			}
-					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-					newErr.model = v
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
 		}
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
@@ -250,9 +250,9 @@ func (a *ModelRulesConfigurationAPIService) GetModelRulesExecute(r ApiGetModelRu
 }
 
 type ApiGetModelRulesByTypeRequest struct {
-	ctx context.Context
-	ApiService *ModelRulesConfigurationAPIService
-	type_ string
+	ctx         context.Context
+	ApiService  *ModelRulesConfigurationAPIService
+	type_       string
 	xScopeOrgID *string
 }
 
@@ -271,26 +271,27 @@ GetModelRulesByType Get base, active, or custom model rules
 
 Retrieves base, active, or custom model rules for the current tenant.
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param type_ Rule set selector.
- @return ApiGetModelRulesByTypeRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param type_ Rule set selector.
+	@return ApiGetModelRulesByTypeRequest
 */
 func (a *ModelRulesConfigurationAPIService) GetModelRulesByType(ctx context.Context, type_ string) ApiGetModelRulesByTypeRequest {
 	return ApiGetModelRulesByTypeRequest{
 		ApiService: a,
-		ctx: ctx,
-		type_: type_,
+		ctx:        ctx,
+		type_:      type_,
 	}
 }
 
 // Execute executes the request
-//  @return ModelRulesDto
+//
+//	@return ModelRulesDto
 func (a *ModelRulesConfigurationAPIService) GetModelRulesByTypeExecute(r ApiGetModelRulesByTypeRequest) (*ModelRulesDto, *http.Response, error) {
 	var (
-		localVarHTTPMethod   = http.MethodGet
-		localVarPostBody     interface{}
-		formFiles            []formFile
-		localVarReturnValue  *ModelRulesDto
+		localVarHTTPMethod  = http.MethodGet
+		localVarPostBody    interface{}
+		formFiles           []formFile
+		localVarReturnValue *ModelRulesDto
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ModelRulesConfigurationAPIService.GetModelRulesByType")
@@ -363,8 +364,8 @@ func (a *ModelRulesConfigurationAPIService) GetModelRulesByTypeExecute(r ApiGetM
 }
 
 type ApiGetModelRulesOntologyRequest struct {
-	ctx context.Context
-	ApiService *ModelRulesConfigurationAPIService
+	ctx         context.Context
+	ApiService  *ModelRulesConfigurationAPIService
 	xScopeOrgID *string
 }
 
@@ -383,24 +384,25 @@ GetModelRulesOntology Get OWL ontology for active model rules
 
 Returns the active (base + custom, vendor-filtered) model rules for the current tenant as an OWL ontology serialized in Turtle. Entity-type classes, harvested datatype properties, and relation object-properties are emitted under the kg-base: namespace; every declaration carries a kg:source annotation with value "base", "custom", or "base+custom" describing which rule set(s) contributed it. The kg: namespace owns framework annotations (kg:name with its owl:cardinality 1 restriction, repeatable kg:scopeProperties, and kg:source itself). The owl:versionInfo is composed from the OOTB rules implementation version and a short SHA-256 fingerprint over the custom rules JSON when any are present. The synthetic 'Assertion' entity type, which exists only in the runtime registry, is intentionally omitted.
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiGetModelRulesOntologyRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiGetModelRulesOntologyRequest
 */
 func (a *ModelRulesConfigurationAPIService) GetModelRulesOntology(ctx context.Context) ApiGetModelRulesOntologyRequest {
 	return ApiGetModelRulesOntologyRequest{
 		ApiService: a,
-		ctx: ctx,
+		ctx:        ctx,
 	}
 }
 
 // Execute executes the request
-//  @return map[string]interface{}
+//
+//	@return map[string]interface{}
 func (a *ModelRulesConfigurationAPIService) GetModelRulesOntologyExecute(r ApiGetModelRulesOntologyRequest) (map[string]interface{}, *http.Response, error) {
 	var (
-		localVarHTTPMethod   = http.MethodGet
-		localVarPostBody     interface{}
-		formFiles            []formFile
-		localVarReturnValue  map[string]interface{}
+		localVarHTTPMethod  = http.MethodGet
+		localVarPostBody    interface{}
+		formFiles           []formFile
+		localVarReturnValue map[string]interface{}
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ModelRulesConfigurationAPIService.GetModelRulesOntology")
@@ -457,14 +459,14 @@ func (a *ModelRulesConfigurationAPIService) GetModelRulesOntologyExecute(r ApiGe
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
-			var v ApiError[string]interface{}
+			var v ApiError
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
 			}
-					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-					newErr.model = v
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
 		}
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
@@ -482,8 +484,8 @@ func (a *ModelRulesConfigurationAPIService) GetModelRulesOntologyExecute(r ApiGe
 }
 
 type ApiGetModelRulesSchemaRequest struct {
-	ctx context.Context
-	ApiService *ModelRulesConfigurationAPIService
+	ctx         context.Context
+	ApiService  *ModelRulesConfigurationAPIService
 	xScopeOrgID *string
 }
 
@@ -502,24 +504,25 @@ GetModelRulesSchema Get JSON Schema for the Model Rules configuration
 
 Returns a JSON Schema Draft 2020-12 document that describes the structure of the Model Rules configuration.
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiGetModelRulesSchemaRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiGetModelRulesSchemaRequest
 */
 func (a *ModelRulesConfigurationAPIService) GetModelRulesSchema(ctx context.Context) ApiGetModelRulesSchemaRequest {
 	return ApiGetModelRulesSchemaRequest{
 		ApiService: a,
-		ctx: ctx,
+		ctx:        ctx,
 	}
 }
 
 // Execute executes the request
-//  @return map[string]interface{}
+//
+//	@return map[string]interface{}
 func (a *ModelRulesConfigurationAPIService) GetModelRulesSchemaExecute(r ApiGetModelRulesSchemaRequest) (map[string]interface{}, *http.Response, error) {
 	var (
-		localVarHTTPMethod   = http.MethodGet
-		localVarPostBody     interface{}
-		formFiles            []formFile
-		localVarReturnValue  map[string]interface{}
+		localVarHTTPMethod  = http.MethodGet
+		localVarPostBody    interface{}
+		formFiles           []formFile
+		localVarReturnValue map[string]interface{}
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ModelRulesConfigurationAPIService.GetModelRulesSchema")
@@ -576,14 +579,14 @@ func (a *ModelRulesConfigurationAPIService) GetModelRulesSchemaExecute(r ApiGetM
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
-			var v ApiError[string]interface{}
+			var v ApiError
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
 			}
-					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-					newErr.model = v
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
 		}
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
@@ -601,8 +604,8 @@ func (a *ModelRulesConfigurationAPIService) GetModelRulesSchemaExecute(r ApiGetM
 }
 
 type ApiListModelRulesRequest struct {
-	ctx context.Context
-	ApiService *ModelRulesConfigurationAPIService
+	ctx         context.Context
+	ApiService  *ModelRulesConfigurationAPIService
 	xScopeOrgID *string
 }
 
@@ -621,24 +624,25 @@ ListModelRules List all custom model rule names
 
 Retrieves a list of all available custom model rule configuration names for the current tenant.
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiListModelRulesRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiListModelRulesRequest
 */
 func (a *ModelRulesConfigurationAPIService) ListModelRules(ctx context.Context) ApiListModelRulesRequest {
 	return ApiListModelRulesRequest{
 		ApiService: a,
-		ctx: ctx,
+		ctx:        ctx,
 	}
 }
 
 // Execute executes the request
-//  @return ModelRuleNamesDto
+//
+//	@return ModelRuleNamesDto
 func (a *ModelRulesConfigurationAPIService) ListModelRulesExecute(r ApiListModelRulesRequest) (*ModelRuleNamesDto, *http.Response, error) {
 	var (
-		localVarHTTPMethod   = http.MethodGet
-		localVarPostBody     interface{}
-		formFiles            []formFile
-		localVarReturnValue  *ModelRuleNamesDto
+		localVarHTTPMethod  = http.MethodGet
+		localVarPostBody    interface{}
+		formFiles           []formFile
+		localVarReturnValue *ModelRuleNamesDto
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ModelRulesConfigurationAPIService.ListModelRules")
@@ -710,9 +714,9 @@ func (a *ModelRulesConfigurationAPIService) ListModelRulesExecute(r ApiListModel
 }
 
 type ApiPutModelRulesRequest struct {
-	ctx context.Context
-	ApiService *ModelRulesConfigurationAPIService
-	body *string
+	ctx         context.Context
+	ApiService  *ModelRulesConfigurationAPIService
+	body        *string
 	xScopeOrgID *string
 }
 
@@ -736,22 +740,22 @@ PutModelRules Create or update custom model rules
 
 Creates or updates custom model rules using the name specified in the request body.
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiPutModelRulesRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiPutModelRulesRequest
 */
 func (a *ModelRulesConfigurationAPIService) PutModelRules(ctx context.Context) ApiPutModelRulesRequest {
 	return ApiPutModelRulesRequest{
 		ApiService: a,
-		ctx: ctx,
+		ctx:        ctx,
 	}
 }
 
 // Execute executes the request
 func (a *ModelRulesConfigurationAPIService) PutModelRulesExecute(r ApiPutModelRulesRequest) (*http.Response, error) {
 	var (
-		localVarHTTPMethod   = http.MethodPut
-		localVarPostBody     interface{}
-		formFiles            []formFile
+		localVarHTTPMethod = http.MethodPut
+		localVarPostBody   interface{}
+		formFiles          []formFile
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ModelRulesConfigurationAPIService.PutModelRules")
@@ -813,25 +817,25 @@ func (a *ModelRulesConfigurationAPIService) PutModelRulesExecute(r ApiPutModelRu
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 422 {
-			var v ApiError[string]interface{}
+			var v ApiError
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarHTTPResponse, newErr
 			}
-					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-					newErr.model = v
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
 			return localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
-			var v ApiError[string]interface{}
+			var v ApiError
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarHTTPResponse, newErr
 			}
-					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-					newErr.model = v
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
 		}
 		return localVarHTTPResponse, newErr
 	}
@@ -840,10 +844,10 @@ func (a *ModelRulesConfigurationAPIService) PutModelRulesExecute(r ApiPutModelRu
 }
 
 type ApiPutModelRulesByNameRequest struct {
-	ctx context.Context
-	ApiService *ModelRulesConfigurationAPIService
-	name string
-	body *string
+	ctx         context.Context
+	ApiService  *ModelRulesConfigurationAPIService
+	name        string
+	body        *string
 	xScopeOrgID *string
 }
 
@@ -867,24 +871,24 @@ PutModelRulesByName Create or update custom model rules by name
 
 Creates or updates custom model rules with a specific name. If the dto also contains a name, it will be used instead (save as operation).
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param name The name of the model rules configuration
- @return ApiPutModelRulesByNameRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param name The name of the model rules configuration
+	@return ApiPutModelRulesByNameRequest
 */
 func (a *ModelRulesConfigurationAPIService) PutModelRulesByName(ctx context.Context, name string) ApiPutModelRulesByNameRequest {
 	return ApiPutModelRulesByNameRequest{
 		ApiService: a,
-		ctx: ctx,
-		name: name,
+		ctx:        ctx,
+		name:       name,
 	}
 }
 
 // Execute executes the request
 func (a *ModelRulesConfigurationAPIService) PutModelRulesByNameExecute(r ApiPutModelRulesByNameRequest) (*http.Response, error) {
 	var (
-		localVarHTTPMethod   = http.MethodPut
-		localVarPostBody     interface{}
-		formFiles            []formFile
+		localVarHTTPMethod = http.MethodPut
+		localVarPostBody   interface{}
+		formFiles          []formFile
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ModelRulesConfigurationAPIService.PutModelRulesByName")
@@ -947,25 +951,25 @@ func (a *ModelRulesConfigurationAPIService) PutModelRulesByNameExecute(r ApiPutM
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 422 {
-			var v ApiError[string]interface{}
+			var v ApiError
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarHTTPResponse, newErr
 			}
-					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-					newErr.model = v
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
 			return localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
-			var v ApiError[string]interface{}
+			var v ApiError
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarHTTPResponse, newErr
 			}
-					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-					newErr.model = v
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
 		}
 		return localVarHTTPResponse, newErr
 	}
@@ -974,9 +978,9 @@ func (a *ModelRulesConfigurationAPIService) PutModelRulesByNameExecute(r ApiPutM
 }
 
 type ApiSearchModelRulesRequest struct {
-	ctx context.Context
-	ApiService *ModelRulesConfigurationAPIService
-	q *string
+	ctx         context.Context
+	ApiService  *ModelRulesConfigurationAPIService
+	q           *string
 	xScopeOrgID *string
 }
 
@@ -1001,24 +1005,25 @@ SearchModelRules Search model rules by keyword
 
 Searches built-in and custom model rule files by case-insensitive substring match against filenames, entity type names, relationship entity types, and vendor keywords. Query must be at least 2 characters.
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiSearchModelRulesRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiSearchModelRulesRequest
 */
 func (a *ModelRulesConfigurationAPIService) SearchModelRules(ctx context.Context) ApiSearchModelRulesRequest {
 	return ApiSearchModelRulesRequest{
 		ApiService: a,
-		ctx: ctx,
+		ctx:        ctx,
 	}
 }
 
 // Execute executes the request
-//  @return ModelRulesSearchResultDto
+//
+//	@return ModelRulesSearchResultDto
 func (a *ModelRulesConfigurationAPIService) SearchModelRulesExecute(r ApiSearchModelRulesRequest) (*ModelRulesSearchResultDto, *http.Response, error) {
 	var (
-		localVarHTTPMethod   = http.MethodGet
-		localVarPostBody     interface{}
-		formFiles            []formFile
-		localVarReturnValue  *ModelRulesSearchResultDto
+		localVarHTTPMethod  = http.MethodGet
+		localVarPostBody    interface{}
+		formFiles           []formFile
+		localVarReturnValue *ModelRulesSearchResultDto
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ModelRulesConfigurationAPIService.SearchModelRules")
@@ -1082,14 +1087,14 @@ func (a *ModelRulesConfigurationAPIService) SearchModelRulesExecute(r ApiSearchM
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 422 {
-			var v ApiError[string]interface{}
+			var v ApiError
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
 			}
-					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-					newErr.model = v
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
 		}
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}

--- a/go/gcom/api_profile_drilldown_config_controller.go
+++ b/go/gcom/api_profile_drilldown_config_controller.go
@@ -20,14 +20,13 @@ import (
 	"strings"
 )
 
-
 // ProfileDrilldownConfigControllerAPIService ProfileDrilldownConfigControllerAPI service
 type ProfileDrilldownConfigControllerAPIService service
 
 type ApiDeleteConfig2Request struct {
-	ctx context.Context
-	ApiService *ProfileDrilldownConfigControllerAPIService
-	name string
+	ctx         context.Context
+	ApiService  *ProfileDrilldownConfigControllerAPIService
+	name        string
 	xScopeOrgID *string
 }
 
@@ -46,24 +45,24 @@ DeleteConfig2 Delete profile drilldown configuration
 
 Deletes the specified profile drilldown configuration entry for the tenant
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param name Name of the profile configuration to delete
- @return ApiDeleteConfig2Request
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param name Name of the profile configuration to delete
+	@return ApiDeleteConfig2Request
 */
 func (a *ProfileDrilldownConfigControllerAPIService) DeleteConfig2(ctx context.Context, name string) ApiDeleteConfig2Request {
 	return ApiDeleteConfig2Request{
 		ApiService: a,
-		ctx: ctx,
-		name: name,
+		ctx:        ctx,
+		name:       name,
 	}
 }
 
 // Execute executes the request
 func (a *ProfileDrilldownConfigControllerAPIService) DeleteConfig2Execute(r ApiDeleteConfig2Request) (*http.Response, error) {
 	var (
-		localVarHTTPMethod   = http.MethodDelete
-		localVarPostBody     interface{}
-		formFiles            []formFile
+		localVarHTTPMethod = http.MethodDelete
+		localVarPostBody   interface{}
+		formFiles          []formFile
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ProfileDrilldownConfigControllerAPIService.DeleteConfig2")
@@ -127,8 +126,8 @@ func (a *ProfileDrilldownConfigControllerAPIService) DeleteConfig2Execute(r ApiD
 }
 
 type ApiGetTenantProfileConfigRequest struct {
-	ctx context.Context
-	ApiService *ProfileDrilldownConfigControllerAPIService
+	ctx         context.Context
+	ApiService  *ProfileDrilldownConfigControllerAPIService
 	xScopeOrgID *string
 }
 
@@ -138,7 +137,7 @@ func (r ApiGetTenantProfileConfigRequest) XScopeOrgID(xScopeOrgID string) ApiGet
 	return r
 }
 
-func (r ApiGetTenantProfileConfigRequest) Execute() (TenantProfileConfigResponseDto[string]interface{}, *http.Response, error) {
+func (r ApiGetTenantProfileConfigRequest) Execute() (*TenantProfileConfigResponseDto, *http.Response, error) {
 	return r.ApiService.GetTenantProfileConfigExecute(r)
 }
 
@@ -147,24 +146,25 @@ GetTenantProfileConfig Get tenant profile configuration
 
 Retrieves all the profile drilldown configuration entries for the tenant
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiGetTenantProfileConfigRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiGetTenantProfileConfigRequest
 */
 func (a *ProfileDrilldownConfigControllerAPIService) GetTenantProfileConfig(ctx context.Context) ApiGetTenantProfileConfigRequest {
 	return ApiGetTenantProfileConfigRequest{
 		ApiService: a,
-		ctx: ctx,
+		ctx:        ctx,
 	}
 }
 
 // Execute executes the request
-//  @return TenantProfileConfigResponseDto[string]interface{}
-func (a *ProfileDrilldownConfigControllerAPIService) GetTenantProfileConfigExecute(r ApiGetTenantProfileConfigRequest) (TenantProfileConfigResponseDto[string]interface{}, *http.Response, error) {
+//
+//	@return TenantProfileConfigResponseDto
+func (a *ProfileDrilldownConfigControllerAPIService) GetTenantProfileConfigExecute(r ApiGetTenantProfileConfigRequest) (*TenantProfileConfigResponseDto, *http.Response, error) {
 	var (
-		localVarHTTPMethod   = http.MethodGet
-		localVarPostBody     interface{}
-		formFiles            []formFile
-		localVarReturnValue  TenantProfileConfigResponseDto[string]interface{}
+		localVarHTTPMethod  = http.MethodGet
+		localVarPostBody    interface{}
+		formFiles           []formFile
+		localVarReturnValue *TenantProfileConfigResponseDto
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ProfileDrilldownConfigControllerAPIService.GetTenantProfileConfig")
@@ -236,9 +236,9 @@ func (a *ProfileDrilldownConfigControllerAPIService) GetTenantProfileConfigExecu
 }
 
 type ApiReorderProfileConfigPrioritiesRequest struct {
-	ctx context.Context
-	ApiService *ProfileDrilldownConfigControllerAPIService
-	body *string
+	ctx         context.Context
+	ApiService  *ProfileDrilldownConfigControllerAPIService
+	body        *string
 	xScopeOrgID *string
 }
 
@@ -262,24 +262,25 @@ ReorderProfileConfigPriorities Reorder profile drilldown configuration prioritie
 
 Accepts a list of profile drilldown configuration names and their new priorities to reorder the configurations for the tenant
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiReorderProfileConfigPrioritiesRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiReorderProfileConfigPrioritiesRequest
 */
 func (a *ProfileDrilldownConfigControllerAPIService) ReorderProfileConfigPriorities(ctx context.Context) ApiReorderProfileConfigPrioritiesRequest {
 	return ApiReorderProfileConfigPrioritiesRequest{
 		ApiService: a,
-		ctx: ctx,
+		ctx:        ctx,
 	}
 }
 
 // Execute executes the request
-//  @return TenantProfileConfigResponseDto
+//
+//	@return TenantProfileConfigResponseDto
 func (a *ProfileDrilldownConfigControllerAPIService) ReorderProfileConfigPrioritiesExecute(r ApiReorderProfileConfigPrioritiesRequest) (*TenantProfileConfigResponseDto, *http.Response, error) {
 	var (
-		localVarHTTPMethod   = http.MethodPut
-		localVarPostBody     interface{}
-		formFiles            []formFile
-		localVarReturnValue  *TenantProfileConfigResponseDto
+		localVarHTTPMethod  = http.MethodPut
+		localVarPostBody    interface{}
+		formFiles           []formFile
+		localVarReturnValue *TenantProfileConfigResponseDto
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ProfileDrilldownConfigControllerAPIService.ReorderProfileConfigPriorities")
@@ -341,14 +342,14 @@ func (a *ProfileDrilldownConfigControllerAPIService) ReorderProfileConfigPriorit
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 422 {
-			var v ApiError[string]interface{}
+			var v ApiError
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
 			}
-					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-					newErr.model = v
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
 		}
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
@@ -366,9 +367,9 @@ func (a *ProfileDrilldownConfigControllerAPIService) ReorderProfileConfigPriorit
 }
 
 type ApiUpsertProfileDrilldownConfigRequest struct {
-	ctx context.Context
-	ApiService *ProfileDrilldownConfigControllerAPIService
-	body *string
+	ctx         context.Context
+	ApiService  *ProfileDrilldownConfigControllerAPIService
+	body        *string
 	xScopeOrgID *string
 }
 
@@ -392,22 +393,22 @@ UpsertProfileDrilldownConfig Upsert profile drilldown configuration
 
 Creates or updates the profile drilldown configuration entry for the tenant
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiUpsertProfileDrilldownConfigRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiUpsertProfileDrilldownConfigRequest
 */
 func (a *ProfileDrilldownConfigControllerAPIService) UpsertProfileDrilldownConfig(ctx context.Context) ApiUpsertProfileDrilldownConfigRequest {
 	return ApiUpsertProfileDrilldownConfigRequest{
 		ApiService: a,
-		ctx: ctx,
+		ctx:        ctx,
 	}
 }
 
 // Execute executes the request
 func (a *ProfileDrilldownConfigControllerAPIService) UpsertProfileDrilldownConfigExecute(r ApiUpsertProfileDrilldownConfigRequest) (*http.Response, error) {
 	var (
-		localVarHTTPMethod   = http.MethodPost
-		localVarPostBody     interface{}
-		formFiles            []formFile
+		localVarHTTPMethod = http.MethodPost
+		localVarPostBody   interface{}
+		formFiles          []formFile
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ProfileDrilldownConfigControllerAPIService.UpsertProfileDrilldownConfig")
@@ -469,14 +470,14 @@ func (a *ProfileDrilldownConfigControllerAPIService) UpsertProfileDrilldownConfi
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 422 {
-			var v ApiError[string]interface{}
+			var v ApiError
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarHTTPResponse, newErr
 			}
-					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-					newErr.model = v
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
 		}
 		return localVarHTTPResponse, newErr
 	}

--- a/go/gcom/api_trace_drilldown_config_controller.go
+++ b/go/gcom/api_trace_drilldown_config_controller.go
@@ -20,14 +20,13 @@ import (
 	"strings"
 )
 
-
 // TraceDrilldownConfigControllerAPIService TraceDrilldownConfigControllerAPI service
 type TraceDrilldownConfigControllerAPIService service
 
 type ApiDeleteConfig1Request struct {
-	ctx context.Context
-	ApiService *TraceDrilldownConfigControllerAPIService
-	name string
+	ctx         context.Context
+	ApiService  *TraceDrilldownConfigControllerAPIService
+	name        string
 	xScopeOrgID *string
 }
 
@@ -46,24 +45,24 @@ DeleteConfig1 Delete trace drilldown configuration
 
 Deletes the specified trace drilldown configuration entry for the tenant
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param name Name of the trace configuration to delete
- @return ApiDeleteConfig1Request
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param name Name of the trace configuration to delete
+	@return ApiDeleteConfig1Request
 */
 func (a *TraceDrilldownConfigControllerAPIService) DeleteConfig1(ctx context.Context, name string) ApiDeleteConfig1Request {
 	return ApiDeleteConfig1Request{
 		ApiService: a,
-		ctx: ctx,
-		name: name,
+		ctx:        ctx,
+		name:       name,
 	}
 }
 
 // Execute executes the request
 func (a *TraceDrilldownConfigControllerAPIService) DeleteConfig1Execute(r ApiDeleteConfig1Request) (*http.Response, error) {
 	var (
-		localVarHTTPMethod   = http.MethodDelete
-		localVarPostBody     interface{}
-		formFiles            []formFile
+		localVarHTTPMethod = http.MethodDelete
+		localVarPostBody   interface{}
+		formFiles          []formFile
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "TraceDrilldownConfigControllerAPIService.DeleteConfig1")
@@ -127,8 +126,8 @@ func (a *TraceDrilldownConfigControllerAPIService) DeleteConfig1Execute(r ApiDel
 }
 
 type ApiGetTenantTraceConfigRequest struct {
-	ctx context.Context
-	ApiService *TraceDrilldownConfigControllerAPIService
+	ctx         context.Context
+	ApiService  *TraceDrilldownConfigControllerAPIService
 	xScopeOrgID *string
 }
 
@@ -138,7 +137,7 @@ func (r ApiGetTenantTraceConfigRequest) XScopeOrgID(xScopeOrgID string) ApiGetTe
 	return r
 }
 
-func (r ApiGetTenantTraceConfigRequest) Execute() (TenantTraceConfigResponseDto[string]interface{}, *http.Response, error) {
+func (r ApiGetTenantTraceConfigRequest) Execute() (*TenantTraceConfigResponseDto, *http.Response, error) {
 	return r.ApiService.GetTenantTraceConfigExecute(r)
 }
 
@@ -147,24 +146,25 @@ GetTenantTraceConfig Get tenant trace configuration
 
 Retrieves all the trace drilldown configuration entries for the tenant
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiGetTenantTraceConfigRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiGetTenantTraceConfigRequest
 */
 func (a *TraceDrilldownConfigControllerAPIService) GetTenantTraceConfig(ctx context.Context) ApiGetTenantTraceConfigRequest {
 	return ApiGetTenantTraceConfigRequest{
 		ApiService: a,
-		ctx: ctx,
+		ctx:        ctx,
 	}
 }
 
 // Execute executes the request
-//  @return TenantTraceConfigResponseDto[string]interface{}
-func (a *TraceDrilldownConfigControllerAPIService) GetTenantTraceConfigExecute(r ApiGetTenantTraceConfigRequest) (TenantTraceConfigResponseDto[string]interface{}, *http.Response, error) {
+//
+//	@return TenantTraceConfigResponseDto
+func (a *TraceDrilldownConfigControllerAPIService) GetTenantTraceConfigExecute(r ApiGetTenantTraceConfigRequest) (*TenantTraceConfigResponseDto, *http.Response, error) {
 	var (
-		localVarHTTPMethod   = http.MethodGet
-		localVarPostBody     interface{}
-		formFiles            []formFile
-		localVarReturnValue  TenantTraceConfigResponseDto[string]interface{}
+		localVarHTTPMethod  = http.MethodGet
+		localVarPostBody    interface{}
+		formFiles           []formFile
+		localVarReturnValue *TenantTraceConfigResponseDto
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "TraceDrilldownConfigControllerAPIService.GetTenantTraceConfig")
@@ -236,9 +236,9 @@ func (a *TraceDrilldownConfigControllerAPIService) GetTenantTraceConfigExecute(r
 }
 
 type ApiReorderTraceConfigPrioritiesRequest struct {
-	ctx context.Context
-	ApiService *TraceDrilldownConfigControllerAPIService
-	body *string
+	ctx         context.Context
+	ApiService  *TraceDrilldownConfigControllerAPIService
+	body        *string
 	xScopeOrgID *string
 }
 
@@ -262,24 +262,25 @@ ReorderTraceConfigPriorities Reorder trace drilldown configuration priorities
 
 Accepts a list of trace drilldown configuration names and their new priorities to reorder the configurations for the tenant
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiReorderTraceConfigPrioritiesRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiReorderTraceConfigPrioritiesRequest
 */
 func (a *TraceDrilldownConfigControllerAPIService) ReorderTraceConfigPriorities(ctx context.Context) ApiReorderTraceConfigPrioritiesRequest {
 	return ApiReorderTraceConfigPrioritiesRequest{
 		ApiService: a,
-		ctx: ctx,
+		ctx:        ctx,
 	}
 }
 
 // Execute executes the request
-//  @return TenantTraceConfigResponseDto
+//
+//	@return TenantTraceConfigResponseDto
 func (a *TraceDrilldownConfigControllerAPIService) ReorderTraceConfigPrioritiesExecute(r ApiReorderTraceConfigPrioritiesRequest) (*TenantTraceConfigResponseDto, *http.Response, error) {
 	var (
-		localVarHTTPMethod   = http.MethodPut
-		localVarPostBody     interface{}
-		formFiles            []formFile
-		localVarReturnValue  *TenantTraceConfigResponseDto
+		localVarHTTPMethod  = http.MethodPut
+		localVarPostBody    interface{}
+		formFiles           []formFile
+		localVarReturnValue *TenantTraceConfigResponseDto
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "TraceDrilldownConfigControllerAPIService.ReorderTraceConfigPriorities")
@@ -341,14 +342,14 @@ func (a *TraceDrilldownConfigControllerAPIService) ReorderTraceConfigPrioritiesE
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 422 {
-			var v ApiError[string]interface{}
+			var v ApiError
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
 			}
-					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-					newErr.model = v
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
 		}
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
@@ -366,9 +367,9 @@ func (a *TraceDrilldownConfigControllerAPIService) ReorderTraceConfigPrioritiesE
 }
 
 type ApiUpsertTraceDrilldownConfigRequest struct {
-	ctx context.Context
-	ApiService *TraceDrilldownConfigControllerAPIService
-	body *string
+	ctx         context.Context
+	ApiService  *TraceDrilldownConfigControllerAPIService
+	body        *string
 	xScopeOrgID *string
 }
 
@@ -392,22 +393,22 @@ UpsertTraceDrilldownConfig Upsert trace drilldown configuration
 
 Creates or updates the trace drilldown configuration entry for the tenant
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiUpsertTraceDrilldownConfigRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiUpsertTraceDrilldownConfigRequest
 */
 func (a *TraceDrilldownConfigControllerAPIService) UpsertTraceDrilldownConfig(ctx context.Context) ApiUpsertTraceDrilldownConfigRequest {
 	return ApiUpsertTraceDrilldownConfigRequest{
 		ApiService: a,
-		ctx: ctx,
+		ctx:        ctx,
 	}
 }
 
 // Execute executes the request
 func (a *TraceDrilldownConfigControllerAPIService) UpsertTraceDrilldownConfigExecute(r ApiUpsertTraceDrilldownConfigRequest) (*http.Response, error) {
 	var (
-		localVarHTTPMethod   = http.MethodPost
-		localVarPostBody     interface{}
-		formFiles            []formFile
+		localVarHTTPMethod = http.MethodPost
+		localVarPostBody   interface{}
+		formFiles          []formFile
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "TraceDrilldownConfigControllerAPIService.UpsertTraceDrilldownConfig")
@@ -469,14 +470,14 @@ func (a *TraceDrilldownConfigControllerAPIService) UpsertTraceDrilldownConfigExe
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 422 {
-			var v ApiError[string]interface{}
+			var v ApiError
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarHTTPResponse, newErr
 			}
-					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-					newErr.model = v
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
 		}
 		return localVarHTTPResponse, newErr
 	}

--- a/go/gcom/docs/AlertConfigurationAPI.md
+++ b/go/gcom/docs/AlertConfigurationAPI.md
@@ -167,7 +167,7 @@ No authorization required
 
 ## GetAllAlertConfigs
 
-> AlertConfigsDto[string]interface{} GetAllAlertConfigs(ctx).XScopeOrgID(xScopeOrgID).Execute()
+> AlertConfigsDto GetAllAlertConfigs(ctx).XScopeOrgID(xScopeOrgID).Execute()
 
 Get all alert configurations
 
@@ -195,7 +195,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Error when calling `AlertConfigurationAPI.GetAllAlertConfigs``: %v\n", err)
 		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
 	}
-	// response from `GetAllAlertConfigs`: AlertConfigsDto[string]interface{}
+	// response from `GetAllAlertConfigs`: AlertConfigsDto
 	fmt.Fprintf(os.Stdout, "Response from `AlertConfigurationAPI.GetAllAlertConfigs`: %v\n", resp)
 }
 ```
@@ -215,7 +215,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**AlertConfigsDto[string]interface{}**
+[**AlertConfigsDto**](AlertConfigsDto.md)
 
 ### Authorization
 
@@ -233,7 +233,7 @@ No authorization required
 
 ## GetAllDisabledAlertConfigs
 
-> DisabledAlertConfigsDto[string]interface{} GetAllDisabledAlertConfigs(ctx).XScopeOrgID(xScopeOrgID).Execute()
+> DisabledAlertConfigsDto GetAllDisabledAlertConfigs(ctx).XScopeOrgID(xScopeOrgID).Execute()
 
 Get all disabled alert configurations
 
@@ -261,7 +261,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Error when calling `AlertConfigurationAPI.GetAllDisabledAlertConfigs``: %v\n", err)
 		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
 	}
-	// response from `GetAllDisabledAlertConfigs`: DisabledAlertConfigsDto[string]interface{}
+	// response from `GetAllDisabledAlertConfigs`: DisabledAlertConfigsDto
 	fmt.Fprintf(os.Stdout, "Response from `AlertConfigurationAPI.GetAllDisabledAlertConfigs`: %v\n", resp)
 }
 ```
@@ -281,7 +281,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**DisabledAlertConfigsDto[string]interface{}**
+[**DisabledAlertConfigsDto**](DisabledAlertConfigsDto.md)
 
 ### Authorization
 
@@ -299,7 +299,7 @@ No authorization required
 
 ## GetDisabledHealthAlertConfigs
 
-> DisabledAlertConfigsDto[string]interface{} GetDisabledHealthAlertConfigs(ctx).XScopeOrgID(xScopeOrgID).Execute()
+> DisabledAlertConfigsDto GetDisabledHealthAlertConfigs(ctx).XScopeOrgID(xScopeOrgID).Execute()
 
 Get disabled health-based alert configurations
 
@@ -327,7 +327,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Error when calling `AlertConfigurationAPI.GetDisabledHealthAlertConfigs``: %v\n", err)
 		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
 	}
-	// response from `GetDisabledHealthAlertConfigs`: DisabledAlertConfigsDto[string]interface{}
+	// response from `GetDisabledHealthAlertConfigs`: DisabledAlertConfigsDto
 	fmt.Fprintf(os.Stdout, "Response from `AlertConfigurationAPI.GetDisabledHealthAlertConfigs`: %v\n", resp)
 }
 ```
@@ -347,7 +347,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**DisabledAlertConfigsDto[string]interface{}**
+[**DisabledAlertConfigsDto**](DisabledAlertConfigsDto.md)
 
 ### Authorization
 
@@ -365,7 +365,7 @@ No authorization required
 
 ## GetDisabledRequestAlertConfigs
 
-> DisabledAlertConfigsDto[string]interface{} GetDisabledRequestAlertConfigs(ctx).XScopeOrgID(xScopeOrgID).Execute()
+> DisabledAlertConfigsDto GetDisabledRequestAlertConfigs(ctx).XScopeOrgID(xScopeOrgID).Execute()
 
 Get disabled request-based alert configurations
 
@@ -393,7 +393,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Error when calling `AlertConfigurationAPI.GetDisabledRequestAlertConfigs``: %v\n", err)
 		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
 	}
-	// response from `GetDisabledRequestAlertConfigs`: DisabledAlertConfigsDto[string]interface{}
+	// response from `GetDisabledRequestAlertConfigs`: DisabledAlertConfigsDto
 	fmt.Fprintf(os.Stdout, "Response from `AlertConfigurationAPI.GetDisabledRequestAlertConfigs`: %v\n", resp)
 }
 ```
@@ -413,7 +413,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**DisabledAlertConfigsDto[string]interface{}**
+[**DisabledAlertConfigsDto**](DisabledAlertConfigsDto.md)
 
 ### Authorization
 
@@ -431,7 +431,7 @@ No authorization required
 
 ## GetDisabledResourceAlertConfigs
 
-> DisabledAlertConfigsDto[string]interface{} GetDisabledResourceAlertConfigs(ctx).XScopeOrgID(xScopeOrgID).Execute()
+> DisabledAlertConfigsDto GetDisabledResourceAlertConfigs(ctx).XScopeOrgID(xScopeOrgID).Execute()
 
 Get disabled resource-based alert configurations
 
@@ -459,7 +459,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Error when calling `AlertConfigurationAPI.GetDisabledResourceAlertConfigs``: %v\n", err)
 		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
 	}
-	// response from `GetDisabledResourceAlertConfigs`: DisabledAlertConfigsDto[string]interface{}
+	// response from `GetDisabledResourceAlertConfigs`: DisabledAlertConfigsDto
 	fmt.Fprintf(os.Stdout, "Response from `AlertConfigurationAPI.GetDisabledResourceAlertConfigs`: %v\n", resp)
 }
 ```
@@ -479,7 +479,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**DisabledAlertConfigsDto[string]interface{}**
+[**DisabledAlertConfigsDto**](DisabledAlertConfigsDto.md)
 
 ### Authorization
 
@@ -497,7 +497,7 @@ No authorization required
 
 ## GetFailureRuleGroups
 
-> PrometheusRuleGroupDto[string]interface{} GetFailureRuleGroups(ctx).CustomFailureRules(customFailureRules).AllFailureRuleGroups(allFailureRuleGroups).XScopeOrgID(xScopeOrgID).Execute()
+> PrometheusRuleGroupDto GetFailureRuleGroups(ctx).CustomFailureRules(customFailureRules).AllFailureRuleGroups(allFailureRuleGroups).XScopeOrgID(xScopeOrgID).Execute()
 
 Get Prometheus failure rule groups
 
@@ -527,7 +527,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Error when calling `AlertConfigurationAPI.GetFailureRuleGroups``: %v\n", err)
 		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
 	}
-	// response from `GetFailureRuleGroups`: PrometheusRuleGroupDto[string]interface{}
+	// response from `GetFailureRuleGroups`: PrometheusRuleGroupDto
 	fmt.Fprintf(os.Stdout, "Response from `AlertConfigurationAPI.GetFailureRuleGroups`: %v\n", resp)
 }
 ```
@@ -549,7 +549,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**PrometheusRuleGroupDto[string]interface{}**
+[**PrometheusRuleGroupDto**](PrometheusRuleGroupDto.md)
 
 ### Authorization
 
@@ -567,7 +567,7 @@ No authorization required
 
 ## GetHealthAlertConfigs
 
-> AlertConfigsDto[string]interface{} GetHealthAlertConfigs(ctx).XScopeOrgID(xScopeOrgID).Execute()
+> AlertConfigsDto GetHealthAlertConfigs(ctx).XScopeOrgID(xScopeOrgID).Execute()
 
 Get health-based alert configurations
 
@@ -595,7 +595,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Error when calling `AlertConfigurationAPI.GetHealthAlertConfigs``: %v\n", err)
 		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
 	}
-	// response from `GetHealthAlertConfigs`: AlertConfigsDto[string]interface{}
+	// response from `GetHealthAlertConfigs`: AlertConfigsDto
 	fmt.Fprintf(os.Stdout, "Response from `AlertConfigurationAPI.GetHealthAlertConfigs`: %v\n", resp)
 }
 ```
@@ -615,7 +615,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**AlertConfigsDto[string]interface{}**
+[**AlertConfigsDto**](AlertConfigsDto.md)
 
 ### Authorization
 
@@ -633,7 +633,7 @@ No authorization required
 
 ## GetRequestAlertConfigs
 
-> AlertConfigsDto[string]interface{} GetRequestAlertConfigs(ctx).XScopeOrgID(xScopeOrgID).Execute()
+> AlertConfigsDto GetRequestAlertConfigs(ctx).XScopeOrgID(xScopeOrgID).Execute()
 
 Get request-based alert configurations
 
@@ -661,7 +661,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Error when calling `AlertConfigurationAPI.GetRequestAlertConfigs``: %v\n", err)
 		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
 	}
-	// response from `GetRequestAlertConfigs`: AlertConfigsDto[string]interface{}
+	// response from `GetRequestAlertConfigs`: AlertConfigsDto
 	fmt.Fprintf(os.Stdout, "Response from `AlertConfigurationAPI.GetRequestAlertConfigs`: %v\n", resp)
 }
 ```
@@ -681,7 +681,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**AlertConfigsDto[string]interface{}**
+[**AlertConfigsDto**](AlertConfigsDto.md)
 
 ### Authorization
 
@@ -699,7 +699,7 @@ No authorization required
 
 ## GetResourceAlertConfigs
 
-> AlertConfigsDto[string]interface{} GetResourceAlertConfigs(ctx).XScopeOrgID(xScopeOrgID).Execute()
+> AlertConfigsDto GetResourceAlertConfigs(ctx).XScopeOrgID(xScopeOrgID).Execute()
 
 Get resource-based alert configurations
 
@@ -727,7 +727,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Error when calling `AlertConfigurationAPI.GetResourceAlertConfigs``: %v\n", err)
 		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
 	}
-	// response from `GetResourceAlertConfigs`: AlertConfigsDto[string]interface{}
+	// response from `GetResourceAlertConfigs`: AlertConfigsDto
 	fmt.Fprintf(os.Stdout, "Response from `AlertConfigurationAPI.GetResourceAlertConfigs`: %v\n", resp)
 }
 ```
@@ -747,7 +747,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**AlertConfigsDto[string]interface{}**
+[**AlertConfigsDto**](AlertConfigsDto.md)
 
 ### Authorization
 
@@ -765,7 +765,7 @@ No authorization required
 
 ## GetSloAlertConfigs
 
-> AlertConfigsDto[string]interface{} GetSloAlertConfigs(ctx).XScopeOrgID(xScopeOrgID).Execute()
+> AlertConfigsDto GetSloAlertConfigs(ctx).XScopeOrgID(xScopeOrgID).Execute()
 
 Get SLO-based alert configurations
 
@@ -793,7 +793,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Error when calling `AlertConfigurationAPI.GetSloAlertConfigs``: %v\n", err)
 		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
 	}
-	// response from `GetSloAlertConfigs`: AlertConfigsDto[string]interface{}
+	// response from `GetSloAlertConfigs`: AlertConfigsDto
 	fmt.Fprintf(os.Stdout, "Response from `AlertConfigurationAPI.GetSloAlertConfigs`: %v\n", resp)
 }
 ```
@@ -813,7 +813,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**AlertConfigsDto[string]interface{}**
+[**AlertConfigsDto**](AlertConfigsDto.md)
 
 ### Authorization
 

--- a/go/gcom/docs/LogDrilldownConfigControllerAPI.md
+++ b/go/gcom/docs/LogDrilldownConfigControllerAPI.md
@@ -83,7 +83,7 @@ No authorization required
 
 ## GetTenantLogConfig
 
-> TenantLogConfigResponseDto[string]interface{} GetTenantLogConfig(ctx).XScopeOrgID(xScopeOrgID).Execute()
+> TenantLogConfigResponseDto GetTenantLogConfig(ctx).XScopeOrgID(xScopeOrgID).Execute()
 
 Get tenant log configuration
 
@@ -111,7 +111,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Error when calling `LogDrilldownConfigControllerAPI.GetTenantLogConfig``: %v\n", err)
 		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
 	}
-	// response from `GetTenantLogConfig`: TenantLogConfigResponseDto[string]interface{}
+	// response from `GetTenantLogConfig`: TenantLogConfigResponseDto
 	fmt.Fprintf(os.Stdout, "Response from `LogDrilldownConfigControllerAPI.GetTenantLogConfig`: %v\n", resp)
 }
 ```
@@ -131,7 +131,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**TenantLogConfigResponseDto[string]interface{}**
+[**TenantLogConfigResponseDto**](TenantLogConfigResponseDto.md)
 
 ### Authorization
 

--- a/go/gcom/docs/ProfileDrilldownConfigControllerAPI.md
+++ b/go/gcom/docs/ProfileDrilldownConfigControllerAPI.md
@@ -83,7 +83,7 @@ No authorization required
 
 ## GetTenantProfileConfig
 
-> TenantProfileConfigResponseDto[string]interface{} GetTenantProfileConfig(ctx).XScopeOrgID(xScopeOrgID).Execute()
+> TenantProfileConfigResponseDto GetTenantProfileConfig(ctx).XScopeOrgID(xScopeOrgID).Execute()
 
 Get tenant profile configuration
 
@@ -111,7 +111,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Error when calling `ProfileDrilldownConfigControllerAPI.GetTenantProfileConfig``: %v\n", err)
 		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
 	}
-	// response from `GetTenantProfileConfig`: TenantProfileConfigResponseDto[string]interface{}
+	// response from `GetTenantProfileConfig`: TenantProfileConfigResponseDto
 	fmt.Fprintf(os.Stdout, "Response from `ProfileDrilldownConfigControllerAPI.GetTenantProfileConfig`: %v\n", resp)
 }
 ```
@@ -131,7 +131,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**TenantProfileConfigResponseDto[string]interface{}**
+[**TenantProfileConfigResponseDto**](TenantProfileConfigResponseDto.md)
 
 ### Authorization
 

--- a/go/gcom/docs/TraceDrilldownConfigControllerAPI.md
+++ b/go/gcom/docs/TraceDrilldownConfigControllerAPI.md
@@ -83,7 +83,7 @@ No authorization required
 
 ## GetTenantTraceConfig
 
-> TenantTraceConfigResponseDto[string]interface{} GetTenantTraceConfig(ctx).XScopeOrgID(xScopeOrgID).Execute()
+> TenantTraceConfigResponseDto GetTenantTraceConfig(ctx).XScopeOrgID(xScopeOrgID).Execute()
 
 Get tenant trace configuration
 
@@ -111,7 +111,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Error when calling `TraceDrilldownConfigControllerAPI.GetTenantTraceConfig``: %v\n", err)
 		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
 	}
-	// response from `GetTenantTraceConfig`: TenantTraceConfigResponseDto[string]interface{}
+	// response from `GetTenantTraceConfig`: TenantTraceConfigResponseDto
 	fmt.Fprintf(os.Stdout, "Response from `TraceDrilldownConfigControllerAPI.GetTenantTraceConfig`: %v\n", resp)
 }
 ```
@@ -131,7 +131,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**TenantTraceConfigResponseDto[string]interface{}**
+[**TenantTraceConfigResponseDto**](TenantTraceConfigResponseDto.md)
 
 ### Authorization
 


### PR DESCRIPTION
## Summary

The generated Go clients **do not compile**. OpenAPI Generator emits invalid Go such as:

```go
var v ApiError[string]interface{}   // syntax error: unexpected keyword interface
```

**Root cause:** springdoc renders every `ApiError` error response as a `$ref` that *also* carries sibling `additionalProperties`/`default` keys:

```yaml
schema:
  $ref: "#/components/schemas/ApiError"
  additionalProperties:     # sibling of $ref -> invalid OpenAPI
    default: ""
  default: ""
```

A `$ref` with sibling keywords is invalid (siblings are ignored unless wrapped in `allOf`), and the Go generator splices the `additionalProperties` map onto the referenced type name, producing `ApiError[string]interface{}`.

This affects **both** the existing `gcom` client (97 occurrences) and the new `kgwrite` client (51) — `go build ./...` fails on both today.

## Fix

Extend `modify-spec.sh` (which already exists to massage these springdoc quirks) to strip `additionalProperties`/`default` **only from maps that contain a `$ref`**, via `yq`. Verified against both specs:

| spec | bad `$ref`-sibling nodes after | `$ref` count | inline `additionalProperties` (no `$ref`) | `HttpStatus` fix |
|------|---|---|---|---|
| gcom | 0 | 826 → 825¹ | 105 → 105 | `type: string` ✓ |
| kgwrite | 0 | 77 → 77 | 10 → 10 | n/a² |

¹ the single drop is the intended `HttpStatusCode` `$ref` removed by the existing `HttpStatus` fix.
² the kg-write group already strips `HttpStatus` upstream.

Legitimate inline `additionalProperties` (e.g. the deepObject `scope` params) are untouched, and `yq` is pre-installed on the `ubuntu-latest` runner where the composite action runs `modify-spec-script`.

> **Stacked on #91.** Merge #91 first (its signed-commit step is what lets the pipeline commit the regenerated clients). Once this and #91 are on `main`, the publish workflow regenerates `gcom`/`kgwrite` as clean, compiling clients.

## Test plan

- [ ] After merge, `go build ./...` succeeds in `go/gcom` and `go/kgwrite`.
- [ ] No `*[string]interface{}` types remain in generated `*.go`.

Made with [Cursor](https://cursor.com)