### PR TITLE
Update KG Write client for delete endpoints

### DIFF
--- a/examples/go/kgwrite-entity-roundtrip/README.md
+++ b/examples/go/kgwrite-entity-roundtrip/README.md
@@ -36,7 +36,12 @@ go run . \
 ```
 
 The `-name` value is used as a base name. The example creates
-`<name>-from` and `<name>-to`, then writes `<relation-type>` between them.
+`<name>-from` and `<name>-to` with scope `env=demo`, then writes
+`<relation-type>` between them.
 
 The example writes `ttlSeconds=-1`, which means the demo entities and
 relationship do not expire before the cleanup delete calls run.
+
+Cleanup uses the collection DELETE endpoints. Entity and relationship identity
+fields are sent as query parameters, including the scope fields needed to match
+the scoped demo entities.

--- a/examples/go/kgwrite-entity-roundtrip/main.go
+++ b/examples/go/kgwrite-entity-roundtrip/main.go
@@ -33,6 +33,7 @@ type appConfig struct {
 	Namespace  string
 	Domain     string
 	EntityType string
+	Scope      map[string]string
 	FromName   string
 	ToName     string
 	Relation   string
@@ -78,6 +79,7 @@ func parseConfig() (appConfig, error) {
 		Namespace:  namespace,
 		Domain:     *domain,
 		EntityType: *entityType,
+		Scope:      map[string]string{"env": "demo"},
 		FromName:   *entityName + "-from",
 		ToName:     *entityName + "-to",
 		Relation:   *relationType,
@@ -122,10 +124,13 @@ func runRoundTrip(ctx context.Context, client *kgwrite.APIClient, cfg appConfig)
 }
 
 func upsertEntity(ctx context.Context, client *kgwrite.APIClient, cfg appConfig, name string) error {
+	entity := kgwrite.NewEntityWriteRequestDto(cfg.Domain, cfg.EntityType, name, noExpiryTTLSeconds)
+	entity.SetScope(cfg.Scope)
+
 	created, response, err := client.KnowledgeGraphWriteAPIAPI.
 		UpsertEntity(ctx, cfg.Namespace).
 		XScopeOrgID(cfg.StackID).
-		EntityWriteRequestDto(*kgwrite.NewEntityWriteRequestDto(cfg.Domain, cfg.EntityType, name, noExpiryTTLSeconds)).
+		EntityWriteRequestDto(*entity).
 		Execute()
 	if err != nil {
 		return fmt.Errorf("create entity %s/%s failed: %w", cfg.EntityType, name, err)
@@ -140,6 +145,8 @@ func upsertEntity(ctx context.Context, client *kgwrite.APIClient, cfg appConfig,
 func upsertRelationship(ctx context.Context, client *kgwrite.APIClient, cfg appConfig) error {
 	from := *kgwrite.NewEntityRefDto(cfg.Domain, cfg.EntityType, cfg.FromName)
 	to := *kgwrite.NewEntityRefDto(cfg.Domain, cfg.EntityType, cfg.ToName)
+	from.SetScope(cfg.Scope)
+	to.SetScope(cfg.Scope)
 
 	fmt.Printf("Creating relationship %s from %s/%s to %s/%s\n", cfg.Relation, from.GetType(), from.GetName(), to.GetType(), to.GetName())
 	created, response, err := client.KnowledgeGraphWriteAPIAPI.
@@ -160,14 +167,17 @@ func upsertRelationship(ctx context.Context, client *kgwrite.APIClient, cfg appC
 func deleteRelationship(ctx context.Context, client *kgwrite.APIClient, cfg appConfig) error {
 	fmt.Printf("Deleting relationship %s from %s/%s to %s/%s\n", cfg.Relation, cfg.EntityType, cfg.FromName, cfg.EntityType, cfg.ToName)
 	response, err := client.KnowledgeGraphWriteAPIAPI.
-		DeleteRelationship(ctx, cfg.Namespace, cfg.Relation).
+		DeleteRelationship(ctx, cfg.Namespace).
 		XScopeOrgID(cfg.StackID).
+		Type_(cfg.Relation).
 		FromDomain(cfg.Domain).
 		FromType(cfg.EntityType).
 		FromName(cfg.FromName).
+		FromScope(cfg.Scope).
 		ToDomain(cfg.Domain).
 		ToType(cfg.EntityType).
 		ToName(cfg.ToName).
+		ToScope(cfg.Scope).
 		Execute()
 	if err != nil {
 		return fmt.Errorf("delete relationship %s failed: %w", cfg.Relation, err)
@@ -182,9 +192,12 @@ func deleteRelationship(ctx context.Context, client *kgwrite.APIClient, cfg appC
 func deleteEntity(ctx context.Context, client *kgwrite.APIClient, cfg appConfig, name string) error {
 	fmt.Printf("Deleting entity %s/%s\n", cfg.EntityType, name)
 	response, err := client.KnowledgeGraphWriteAPIAPI.
-		DeleteEntity(ctx, cfg.Namespace, cfg.EntityType, name).
+		DeleteEntity(ctx, cfg.Namespace).
 		XScopeOrgID(cfg.StackID).
 		Domain(cfg.Domain).
+		Type_(cfg.EntityType).
+		Name(name).
+		Scope(cfg.Scope).
 		Execute()
 	if err != nil {
 		return fmt.Errorf("delete entity %s/%s failed: %w", cfg.EntityType, name, err)

--- a/go/kgwrite/README.md
+++ b/go/kgwrite/README.md
@@ -79,8 +79,8 @@ All URIs are relative to *http://localhost:8030/api-server*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
-*KnowledgeGraphWriteAPIAPI* | [**DeleteEntity**](docs/KnowledgeGraphWriteAPIAPI.md#deleteentity) | **Delete** /apis/kg.grafana.com/v1alpha1/namespaces/{namespace}/entities/{type}/{name} | Delete a custom entity
-*KnowledgeGraphWriteAPIAPI* | [**DeleteRelationship**](docs/KnowledgeGraphWriteAPIAPI.md#deleterelationship) | **Delete** /apis/kg.grafana.com/v1alpha1/namespaces/{namespace}/relationships/{type} | Delete a custom relationship
+*KnowledgeGraphWriteAPIAPI* | [**DeleteEntity**](docs/KnowledgeGraphWriteAPIAPI.md#deleteentity) | **Delete** /apis/kg.grafana.com/v1alpha1/namespaces/{namespace}/entities | Delete a custom entity
+*KnowledgeGraphWriteAPIAPI* | [**DeleteRelationship**](docs/KnowledgeGraphWriteAPIAPI.md#deleterelationship) | **Delete** /apis/kg.grafana.com/v1alpha1/namespaces/{namespace}/relationships | Delete a custom relationship
 *KnowledgeGraphWriteAPIAPI* | [**UpsertEntity**](docs/KnowledgeGraphWriteAPIAPI.md#upsertentity) | **Post** /apis/kg.grafana.com/v1alpha1/namespaces/{namespace}/entities | Create or update a custom entity
 *KnowledgeGraphWriteAPIAPI* | [**UpsertRelationship**](docs/KnowledgeGraphWriteAPIAPI.md#upsertrelationship) | **Post** /apis/kg.grafana.com/v1alpha1/namespaces/{namespace}/relationships | Create or update a custom relationship
 

--- a/go/kgwrite/api/openapi.yaml
+++ b/go/kgwrite/api/openapi.yaml
@@ -17,6 +17,158 @@ tags:
   name: Knowledge Graph Write API
 paths:
   /apis/kg.grafana.com/v1alpha1/namespaces/{namespace}/relationships:
+    delete:
+      description: "Deletes an API-origin edge between the from/to entities. The relationship\
+        \ coordinates travel as query params (no request body): type, plus from.domain/from.type/from.name\
+        \ (+ from.scope[key]=value) and the matching to.* params. Putting type in\
+        \ the query string matches the entity DELETE shape on the collection path."
+      operationId: deleteRelationship
+      parameters:
+      - description: "Tenant namespace, formatted as stacks-<stackId>"
+        explode: false
+        in: path
+        name: namespace
+        required: true
+        schema:
+          default: ""
+          type: string
+        style: simple
+      - explode: true
+        in: query
+        name: type
+        required: true
+        schema:
+          minLength: 1
+          pattern: "^[A-Za-z][A-Za-z0-9_]*$"
+          type: string
+        style: form
+      - explode: true
+        in: query
+        name: from.domain
+        required: true
+        schema:
+          minLength: 1
+          pattern: "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$"
+          type: string
+        style: form
+      - explode: true
+        in: query
+        name: from.type
+        required: true
+        schema:
+          minLength: 1
+          pattern: "^[A-Za-z][A-Za-z0-9_]*$"
+          type: string
+        style: form
+      - explode: true
+        in: query
+        name: from.name
+        required: true
+        schema:
+          minLength: 1
+          type: string
+        style: form
+      - explode: true
+        in: query
+        name: to.domain
+        required: true
+        schema:
+          minLength: 1
+          pattern: "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$"
+          type: string
+        style: form
+      - explode: true
+        in: query
+        name: to.type
+        required: true
+        schema:
+          minLength: 1
+          pattern: "^[A-Za-z][A-Za-z0-9_]*$"
+          type: string
+        style: form
+      - explode: true
+        in: query
+        name: to.name
+        required: true
+        schema:
+          minLength: 1
+          type: string
+        style: form
+      - description: "Optional scope key/value pairs identifying the 'from' entity\
+          \ (from.scope[key]=value)."
+        explode: true
+        in: query
+        name: from.scope
+        required: false
+        schema:
+          additionalProperties:
+            type: string
+        style: deepObject
+      - description: "Optional scope key/value pairs identifying the 'to' entity (to.scope[key]=value)."
+        explode: true
+        in: query
+        name: to.scope
+        required: false
+        schema:
+          additionalProperties:
+            type: string
+        style: deepObject
+      - $ref: '#/components/parameters/TenantId'
+      responses:
+        "204":
+          description: Relationship deleted
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+            application/x-yml:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+            application/x-yaml:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+          description: Missing tenant context or malformed namespace
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+            application/x-yml:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+            application/x-yaml:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+          description: "Namespace does not match the request tenant, or edge is not\
+            \ API-origin"
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+            application/x-yml:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+            application/x-yaml:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+          description: Relationship not found
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+            application/x-yml:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+            application/x-yaml:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+          description: Query params failed validation
+      summary: Delete a custom relationship
+      tags:
+      - Knowledge Graph Write API
     post:
       description: Upserts an API-origin edge between two existing entities; both
         endpoints must already exist.
@@ -121,6 +273,115 @@ paths:
       tags:
       - Knowledge Graph Write API
   /apis/kg.grafana.com/v1alpha1/namespaces/{namespace}/entities:
+    delete:
+      description: "Deletes an API-origin entity; only _origin=api objects may be\
+        \ deleted. The entity coordinates travel as query params (no request body):\
+        \ domain, type, and name, plus an optional nested scope map (scope[key]=value).\
+        \ Putting name in the query string (not the path) allows names that contain\
+        \ '/'."
+      operationId: deleteEntity
+      parameters:
+      - description: "Tenant namespace, formatted as stacks-<stackId>"
+        explode: false
+        in: path
+        name: namespace
+        required: true
+        schema:
+          default: ""
+          type: string
+        style: simple
+      - explode: true
+        in: query
+        name: domain
+        required: true
+        schema:
+          minLength: 1
+          pattern: "^(?!kg$)[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$"
+          type: string
+        style: form
+      - explode: true
+        in: query
+        name: type
+        required: true
+        schema:
+          minLength: 1
+          pattern: "^[A-Za-z][A-Za-z0-9_]*$"
+          type: string
+        style: form
+      - explode: true
+        in: query
+        name: name
+        required: true
+        schema:
+          minLength: 1
+          type: string
+        style: form
+      - description: "Optional scope key/value pairs identifying the entity (scope[key]=value)."
+        explode: true
+        in: query
+        name: scope
+        required: false
+        schema:
+          additionalProperties:
+            type: string
+        style: deepObject
+      - $ref: '#/components/parameters/TenantId'
+      responses:
+        "204":
+          description: Entity deleted
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+            application/x-yml:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+            application/x-yaml:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+          description: "Missing tenant context, malformed namespace, or invalid type/scope\
+            \ key"
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+            application/x-yml:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+            application/x-yaml:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+          description: "Namespace does not match the request tenant, or target is\
+            \ not API-origin"
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+            application/x-yml:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+            application/x-yaml:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+          description: Entity not found
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+            application/x-yml:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+            application/x-yaml:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+          description: Query params failed validation
+      summary: Delete a custom entity
+      tags:
+      - Knowledge Graph Write API
     post:
       description: "Upserts an API-origin entity identified by (type, name, scope):\
         \ 201 on create, 200 on update."
@@ -224,273 +485,6 @@ paths:
           description: Request body failed validation (including an invalid entity
             type)
       summary: Create or update a custom entity
-      tags:
-      - Knowledge Graph Write API
-  /apis/kg.grafana.com/v1alpha1/namespaces/{namespace}/relationships/{type}:
-    delete:
-      description: "Deletes an API-origin edge of the given type between the from/to\
-        \ entities. The endpoint coordinates travel as query params (no request body):\
-        \ from.domain/from.type/from.name (+ from.scope[key]=value) and the matching\
-        \ to.* params."
-      operationId: deleteRelationship
-      parameters:
-      - description: "Tenant namespace, formatted as stacks-<stackId>"
-        explode: false
-        in: path
-        name: namespace
-        required: true
-        schema:
-          default: ""
-          type: string
-        style: simple
-      - description: Relationship type
-        explode: false
-        in: path
-        name: type
-        required: true
-        schema:
-          default: ""
-          pattern: "^[A-Za-z][A-Za-z0-9_]*$"
-          type: string
-        style: simple
-      - explode: true
-        in: query
-        name: from.domain
-        required: true
-        schema:
-          minLength: 1
-          pattern: "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$"
-          type: string
-        style: form
-      - explode: true
-        in: query
-        name: from.type
-        required: true
-        schema:
-          minLength: 1
-          pattern: "^[A-Za-z][A-Za-z0-9_]*$"
-          type: string
-        style: form
-      - explode: true
-        in: query
-        name: from.name
-        required: true
-        schema:
-          minLength: 1
-          type: string
-        style: form
-      - explode: true
-        in: query
-        name: to.domain
-        required: true
-        schema:
-          minLength: 1
-          pattern: "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$"
-          type: string
-        style: form
-      - explode: true
-        in: query
-        name: to.type
-        required: true
-        schema:
-          minLength: 1
-          pattern: "^[A-Za-z][A-Za-z0-9_]*$"
-          type: string
-        style: form
-      - explode: true
-        in: query
-        name: to.name
-        required: true
-        schema:
-          minLength: 1
-          type: string
-        style: form
-      - description: "Optional scope key/value pairs identifying the 'from' entity\
-          \ (from.scope[key]=value)."
-        explode: true
-        in: query
-        name: from.scope
-        required: false
-        schema:
-          additionalProperties:
-            type: string
-        style: deepObject
-      - description: "Optional scope key/value pairs identifying the 'to' entity (to.scope[key]=value)."
-        explode: true
-        in: query
-        name: to.scope
-        required: false
-        schema:
-          additionalProperties:
-            type: string
-        style: deepObject
-      - $ref: '#/components/parameters/TenantId'
-      responses:
-        "204":
-          description: Relationship deleted
-        "400":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiError'
-            application/x-yml:
-              schema:
-                $ref: '#/components/schemas/ApiError'
-            application/x-yaml:
-              schema:
-                $ref: '#/components/schemas/ApiError'
-          description: "Missing tenant context, malformed namespace, or invalid relationship\
-            \ type"
-        "403":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiError'
-            application/x-yml:
-              schema:
-                $ref: '#/components/schemas/ApiError'
-            application/x-yaml:
-              schema:
-                $ref: '#/components/schemas/ApiError'
-          description: "Namespace does not match the request tenant, or edge is not\
-            \ API-origin"
-        "404":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiError'
-            application/x-yml:
-              schema:
-                $ref: '#/components/schemas/ApiError'
-            application/x-yaml:
-              schema:
-                $ref: '#/components/schemas/ApiError'
-          description: Relationship not found
-        "422":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiError'
-            application/x-yml:
-              schema:
-                $ref: '#/components/schemas/ApiError'
-            application/x-yaml:
-              schema:
-                $ref: '#/components/schemas/ApiError'
-          description: "Query params failed validation, or the relationship type path\
-            \ variable is invalid"
-      summary: Delete a custom relationship
-      tags:
-      - Knowledge Graph Write API
-  /apis/kg.grafana.com/v1alpha1/namespaces/{namespace}/entities/{type}/{name}:
-    delete:
-      description: "Deletes an API-origin entity; only _origin=api objects may be\
-        \ deleted. The entity coordinates travel as query params (no request body):\
-        \ the top-level 'domain' control param plus an optional nested scope map (scope[key]=value)."
-      operationId: deleteEntity
-      parameters:
-      - description: "Tenant namespace, formatted as stacks-<stackId>"
-        explode: false
-        in: path
-        name: namespace
-        required: true
-        schema:
-          default: ""
-          type: string
-        style: simple
-      - description: Entity type
-        explode: false
-        in: path
-        name: type
-        required: true
-        schema:
-          default: ""
-          pattern: "^[A-Za-z][A-Za-z0-9_]*$"
-          type: string
-        style: simple
-      - description: Entity name
-        explode: false
-        in: path
-        name: name
-        required: true
-        schema:
-          default: ""
-          type: string
-        style: simple
-      - explode: true
-        in: query
-        name: domain
-        required: true
-        schema:
-          minLength: 1
-          pattern: "^(?!kg$)[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$"
-          type: string
-        style: form
-      - description: "Optional scope key/value pairs identifying the entity (scope[key]=value)."
-        explode: true
-        in: query
-        name: scope
-        required: false
-        schema:
-          additionalProperties:
-            type: string
-        style: deepObject
-      - $ref: '#/components/parameters/TenantId'
-      responses:
-        "204":
-          description: Entity deleted
-        "400":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiError'
-            application/x-yml:
-              schema:
-                $ref: '#/components/schemas/ApiError'
-            application/x-yaml:
-              schema:
-                $ref: '#/components/schemas/ApiError'
-          description: "Missing tenant context, malformed namespace, or invalid type/scope\
-            \ key"
-        "403":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiError'
-            application/x-yml:
-              schema:
-                $ref: '#/components/schemas/ApiError'
-            application/x-yaml:
-              schema:
-                $ref: '#/components/schemas/ApiError'
-          description: "Namespace does not match the request tenant, or target is\
-            \ not API-origin"
-        "404":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiError'
-            application/x-yml:
-              schema:
-                $ref: '#/components/schemas/ApiError'
-            application/x-yaml:
-              schema:
-                $ref: '#/components/schemas/ApiError'
-          description: Entity not found
-        "422":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiError'
-            application/x-yml:
-              schema:
-                $ref: '#/components/schemas/ApiError'
-            application/x-yaml:
-              schema:
-                $ref: '#/components/schemas/ApiError'
-          description: "Query params failed validation, or the entity type path variable\
-            \ is invalid"
-      summary: Delete a custom entity
       tags:
       - Knowledge Graph Write API
 components:

--- a/go/kgwrite/api_knowledge_graph_write_api.go
+++ b/go/kgwrite/api_knowledge_graph_write_api.go
@@ -27,15 +27,25 @@ type ApiDeleteEntityRequest struct {
 	ctx         context.Context
 	ApiService  *KnowledgeGraphWriteAPIAPIService
 	namespace   string
-	type_       string
-	name        string
 	domain      *string
+	type_       *string
+	name        *string
 	scope       *map[string]string
 	xScopeOrgID *string
 }
 
 func (r ApiDeleteEntityRequest) Domain(domain string) ApiDeleteEntityRequest {
 	r.domain = &domain
+	return r
+}
+
+func (r ApiDeleteEntityRequest) Type_(type_ string) ApiDeleteEntityRequest {
+	r.type_ = &type_
+	return r
+}
+
+func (r ApiDeleteEntityRequest) Name(name string) ApiDeleteEntityRequest {
+	r.name = &name
 	return r
 }
 
@@ -58,21 +68,17 @@ func (r ApiDeleteEntityRequest) Execute() (*http.Response, error) {
 /*
 DeleteEntity Delete a custom entity
 
-Deletes an API-origin entity; only _origin=api objects may be deleted. The entity coordinates travel as query params (no request body): the top-level 'domain' control param plus an optional nested scope map (scope[key]=value).
+Deletes an API-origin entity; only _origin=api objects may be deleted. The entity coordinates travel as query params (no request body): domain, type, and name, plus an optional nested scope map (scope[key]=value). Putting name in the query string (not the path) allows names that contain '/'.
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param namespace Tenant namespace, formatted as stacks-<stackId>
-	@param type_ Entity type
-	@param name Entity name
 	@return ApiDeleteEntityRequest
 */
-func (a *KnowledgeGraphWriteAPIAPIService) DeleteEntity(ctx context.Context, namespace string, type_ string, name string) ApiDeleteEntityRequest {
+func (a *KnowledgeGraphWriteAPIAPIService) DeleteEntity(ctx context.Context, namespace string) ApiDeleteEntityRequest {
 	return ApiDeleteEntityRequest{
 		ApiService: a,
 		ctx:        ctx,
 		namespace:  namespace,
-		type_:      type_,
-		name:       name,
 	}
 }
 
@@ -89,10 +95,8 @@ func (a *KnowledgeGraphWriteAPIAPIService) DeleteEntityExecute(r ApiDeleteEntity
 		return nil, &GenericOpenAPIError{error: err.Error()}
 	}
 
-	localVarPath := localBasePath + "/apis/kg.grafana.com/v1alpha1/namespaces/{namespace}/entities/{type}/{name}"
+	localVarPath := localBasePath + "/apis/kg.grafana.com/v1alpha1/namespaces/{namespace}/entities"
 	localVarPath = strings.Replace(localVarPath, "{"+"namespace"+"}", url.PathEscape(parameterValueToString(r.namespace, "namespace")), -1)
-	localVarPath = strings.Replace(localVarPath, "{"+"type"+"}", url.PathEscape(parameterValueToString(r.type_, "type_")), -1)
-	localVarPath = strings.Replace(localVarPath, "{"+"name"+"}", url.PathEscape(parameterValueToString(r.name, "name")), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -103,8 +107,22 @@ func (a *KnowledgeGraphWriteAPIAPIService) DeleteEntityExecute(r ApiDeleteEntity
 	if strlen(*r.domain) < 1 {
 		return nil, reportError("domain must have at least 1 elements")
 	}
+	if r.type_ == nil {
+		return nil, reportError("type_ is required and must be specified")
+	}
+	if strlen(*r.type_) < 1 {
+		return nil, reportError("type_ must have at least 1 elements")
+	}
+	if r.name == nil {
+		return nil, reportError("name is required and must be specified")
+	}
+	if strlen(*r.name) < 1 {
+		return nil, reportError("name must have at least 1 elements")
+	}
 
 	parameterAddToHeaderOrQuery(localVarQueryParams, "domain", r.domain, "")
+	parameterAddToHeaderOrQuery(localVarQueryParams, "type", r.type_, "")
+	parameterAddToHeaderOrQuery(localVarQueryParams, "name", r.name, "")
 	if r.scope != nil {
 		parameterAddToHeaderOrQuery(localVarQueryParams, "scope", r.scope, "")
 	}
@@ -203,7 +221,7 @@ type ApiDeleteRelationshipRequest struct {
 	ctx         context.Context
 	ApiService  *KnowledgeGraphWriteAPIAPIService
 	namespace   string
-	type_       string
+	type_       *string
 	fromDomain  *string
 	fromType    *string
 	fromName    *string
@@ -213,6 +231,11 @@ type ApiDeleteRelationshipRequest struct {
 	fromScope   *map[string]string
 	toScope     *map[string]string
 	xScopeOrgID *string
+}
+
+func (r ApiDeleteRelationshipRequest) Type_(type_ string) ApiDeleteRelationshipRequest {
+	r.type_ = &type_
+	return r
 }
 
 func (r ApiDeleteRelationshipRequest) FromDomain(fromDomain string) ApiDeleteRelationshipRequest {
@@ -270,19 +293,17 @@ func (r ApiDeleteRelationshipRequest) Execute() (*http.Response, error) {
 /*
 DeleteRelationship Delete a custom relationship
 
-Deletes an API-origin edge of the given type between the from/to entities. The endpoint coordinates travel as query params (no request body): from.domain/from.type/from.name (+ from.scope[key]=value) and the matching to.* params.
+Deletes an API-origin edge between the from/to entities. The relationship coordinates travel as query params (no request body): type, plus from.domain/from.type/from.name (+ from.scope[key]=value) and the matching to.* params. Putting type in the query string matches the entity DELETE shape on the collection path.
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param namespace Tenant namespace, formatted as stacks-<stackId>
-	@param type_ Relationship type
 	@return ApiDeleteRelationshipRequest
 */
-func (a *KnowledgeGraphWriteAPIAPIService) DeleteRelationship(ctx context.Context, namespace string, type_ string) ApiDeleteRelationshipRequest {
+func (a *KnowledgeGraphWriteAPIAPIService) DeleteRelationship(ctx context.Context, namespace string) ApiDeleteRelationshipRequest {
 	return ApiDeleteRelationshipRequest{
 		ApiService: a,
 		ctx:        ctx,
 		namespace:  namespace,
-		type_:      type_,
 	}
 }
 
@@ -299,13 +320,18 @@ func (a *KnowledgeGraphWriteAPIAPIService) DeleteRelationshipExecute(r ApiDelete
 		return nil, &GenericOpenAPIError{error: err.Error()}
 	}
 
-	localVarPath := localBasePath + "/apis/kg.grafana.com/v1alpha1/namespaces/{namespace}/relationships/{type}"
+	localVarPath := localBasePath + "/apis/kg.grafana.com/v1alpha1/namespaces/{namespace}/relationships"
 	localVarPath = strings.Replace(localVarPath, "{"+"namespace"+"}", url.PathEscape(parameterValueToString(r.namespace, "namespace")), -1)
-	localVarPath = strings.Replace(localVarPath, "{"+"type"+"}", url.PathEscape(parameterValueToString(r.type_, "type_")), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
+	if r.type_ == nil {
+		return nil, reportError("type_ is required and must be specified")
+	}
+	if strlen(*r.type_) < 1 {
+		return nil, reportError("type_ must have at least 1 elements")
+	}
 	if r.fromDomain == nil {
 		return nil, reportError("fromDomain is required and must be specified")
 	}
@@ -343,6 +369,7 @@ func (a *KnowledgeGraphWriteAPIAPIService) DeleteRelationshipExecute(r ApiDelete
 		return nil, reportError("toName must have at least 1 elements")
 	}
 
+	parameterAddToHeaderOrQuery(localVarQueryParams, "type", r.type_, "")
 	parameterAddToHeaderOrQuery(localVarQueryParams, "from.domain", r.fromDomain, "")
 	parameterAddToHeaderOrQuery(localVarQueryParams, "from.type", r.fromType, "")
 	parameterAddToHeaderOrQuery(localVarQueryParams, "from.name", r.fromName, "")

--- a/go/kgwrite/docs/KnowledgeGraphWriteAPIAPI.md
+++ b/go/kgwrite/docs/KnowledgeGraphWriteAPIAPI.md
@@ -33,9 +33,9 @@ import (
 
 func main() {
 	namespace := "namespace_example" // string | Tenant namespace, formatted as stacks-<stackId> (default to "")
-	domain := "domain_example" // string |
-	type_ := "type__example" // string |
-	name := "name_example" // string |
+	domain := "domain_example" // string | 
+	type_ := "type__example" // string | 
+	name := "name_example" // string | 
 	scope := map[string]string{"key": map[string]string{"key": "Inner_example"}} // map[string]string | Optional scope key/value pairs identifying the entity (scope[key]=value). (optional)
 	xScopeOrgID := "2944" // string | Grafana Tenant/Stack ID (optional)
 
@@ -65,11 +65,11 @@ Other parameters are passed through a pointer to a apiDeleteEntityRequest struct
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 
- **domain** | **string** |  |
- **type_** | **string** |  |
- **name** | **string** |  |
- **scope** | **map[string]map[string]string** | Optional scope key/value pairs identifying the entity (scope[key]&#x3D;value). |
- **xScopeOrgID** | **string** | Grafana Tenant/Stack ID |
+ **domain** | **string** |  | 
+ **type_** | **string** |  | 
+ **name** | **string** |  | 
+ **scope** | **map[string]map[string]string** | Optional scope key/value pairs identifying the entity (scope[key]&#x3D;value). | 
+ **xScopeOrgID** | **string** | Grafana Tenant/Stack ID | 
 
 ### Return type
 
@@ -111,13 +111,13 @@ import (
 
 func main() {
 	namespace := "namespace_example" // string | Tenant namespace, formatted as stacks-<stackId> (default to "")
-	type_ := "type__example" // string |
-	fromDomain := "fromDomain_example" // string |
-	fromType := "fromType_example" // string |
-	fromName := "fromName_example" // string |
-	toDomain := "toDomain_example" // string |
-	toType := "toType_example" // string |
-	toName := "toName_example" // string |
+	type_ := "type__example" // string | 
+	fromDomain := "fromDomain_example" // string | 
+	fromType := "fromType_example" // string | 
+	fromName := "fromName_example" // string | 
+	toDomain := "toDomain_example" // string | 
+	toType := "toType_example" // string | 
+	toName := "toName_example" // string | 
 	fromScope := map[string]string{"key": map[string]string{"key": "Inner_example"}} // map[string]string | Optional scope key/value pairs identifying the 'from' entity (from.scope[key]=value). (optional)
 	toScope := map[string]string{"key": map[string]string{"key": "Inner_example"}} // map[string]string | Optional scope key/value pairs identifying the 'to' entity (to.scope[key]=value). (optional)
 	xScopeOrgID := "2944" // string | Grafana Tenant/Stack ID (optional)
@@ -148,16 +148,16 @@ Other parameters are passed through a pointer to a apiDeleteRelationshipRequest 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 
- **type_** | **string** |  |
- **fromDomain** | **string** |  |
- **fromType** | **string** |  |
- **fromName** | **string** |  |
- **toDomain** | **string** |  |
- **toType** | **string** |  |
- **toName** | **string** |  |
- **fromScope** | **map[string]map[string]string** | Optional scope key/value pairs identifying the &#39;from&#39; entity (from.scope[key]&#x3D;value). |
- **toScope** | **map[string]map[string]string** | Optional scope key/value pairs identifying the &#39;to&#39; entity (to.scope[key]&#x3D;value). |
- **xScopeOrgID** | **string** | Grafana Tenant/Stack ID |
+ **type_** | **string** |  | 
+ **fromDomain** | **string** |  | 
+ **fromType** | **string** |  | 
+ **fromName** | **string** |  | 
+ **toDomain** | **string** |  | 
+ **toType** | **string** |  | 
+ **toName** | **string** |  | 
+ **fromScope** | **map[string]map[string]string** | Optional scope key/value pairs identifying the &#39;from&#39; entity (from.scope[key]&#x3D;value). | 
+ **toScope** | **map[string]map[string]string** | Optional scope key/value pairs identifying the &#39;to&#39; entity (to.scope[key]&#x3D;value). | 
+ **xScopeOrgID** | **string** | Grafana Tenant/Stack ID | 
 
 ### Return type
 
@@ -199,7 +199,7 @@ import (
 
 func main() {
 	namespace := "namespace_example" // string | Tenant namespace, formatted as stacks-<stackId>; must match the request tenant (default to "")
-	entityWriteRequestDto := *openapiclient.NewEntityWriteRequestDto("Domain_example", "Type_example", "Name_example", int64(-1)) // EntityWriteRequestDto |
+	entityWriteRequestDto := *openapiclient.NewEntityWriteRequestDto("Domain_example", "Type_example", "Name_example", int64(-1)) // EntityWriteRequestDto | 
 	xScopeOrgID := "2944" // string | Grafana Tenant/Stack ID (optional)
 
 	configuration := openapiclient.NewConfiguration()
@@ -230,8 +230,8 @@ Other parameters are passed through a pointer to a apiUpsertEntityRequest struct
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 
- **entityWriteRequestDto** | [**EntityWriteRequestDto**](EntityWriteRequestDto.md) |  |
- **xScopeOrgID** | **string** | Grafana Tenant/Stack ID |
+ **entityWriteRequestDto** | [**EntityWriteRequestDto**](EntityWriteRequestDto.md) |  | 
+ **xScopeOrgID** | **string** | Grafana Tenant/Stack ID | 
 
 ### Return type
 
@@ -273,7 +273,7 @@ import (
 
 func main() {
 	namespace := "namespace_example" // string | Tenant namespace, formatted as stacks-<stackId> (default to "")
-	relationshipWriteRequestDto := *openapiclient.NewRelationshipWriteRequestDto("Domain_example", "Type_example", *openapiclient.NewEntityRefDto("Domain_example", "Type_example", "Name_example"), *openapiclient.NewEntityRefDto("Domain_example", "Type_example", "Name_example"), int64(-1)) // RelationshipWriteRequestDto |
+	relationshipWriteRequestDto := *openapiclient.NewRelationshipWriteRequestDto("Domain_example", "Type_example", *openapiclient.NewEntityRefDto("Domain_example", "Type_example", "Name_example"), *openapiclient.NewEntityRefDto("Domain_example", "Type_example", "Name_example"), int64(-1)) // RelationshipWriteRequestDto | 
 	xScopeOrgID := "2944" // string | Grafana Tenant/Stack ID (optional)
 
 	configuration := openapiclient.NewConfiguration()
@@ -304,8 +304,8 @@ Other parameters are passed through a pointer to a apiUpsertRelationshipRequest 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 
- **relationshipWriteRequestDto** | [**RelationshipWriteRequestDto**](RelationshipWriteRequestDto.md) |  |
- **xScopeOrgID** | **string** | Grafana Tenant/Stack ID |
+ **relationshipWriteRequestDto** | [**RelationshipWriteRequestDto**](RelationshipWriteRequestDto.md) |  | 
+ **xScopeOrgID** | **string** | Grafana Tenant/Stack ID | 
 
 ### Return type
 

--- a/go/kgwrite/docs/KnowledgeGraphWriteAPIAPI.md
+++ b/go/kgwrite/docs/KnowledgeGraphWriteAPIAPI.md
@@ -33,10 +33,10 @@ import (
 
 func main() {
 	namespace := "namespace_example" // string | Tenant namespace, formatted as stacks-<stackId> (default to "")
-	domain := "domain_example" // string |
-	type_ := "type__example" // string |
-	name := "name_example" // string |
-	scope := map[string]string{"env": "prod"} // map[string]string | Optional scope key/value pairs identifying the entity (scope[key]=value). (optional)
+	domain := "domain_example" // string | 
+	type_ := "type__example" // string | 
+	name := "name_example" // string | 
+	scope := map[string]string{"key": map[string]string{"key": "Inner_example"}} // map[string]string | Optional scope key/value pairs identifying the entity (scope[key]=value). (optional)
 	xScopeOrgID := "2944" // string | Grafana Tenant/Stack ID (optional)
 
 	configuration := openapiclient.NewConfiguration()
@@ -65,11 +65,11 @@ Other parameters are passed through a pointer to a apiDeleteEntityRequest struct
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 
- **domain** | **string** |  |
- **type_** | **string** |  |
- **name** | **string** |  |
- **scope** | **map[string]string** | Optional scope key/value pairs identifying the entity (scope[key]&#x3D;value). |
- **xScopeOrgID** | **string** | Grafana Tenant/Stack ID |
+ **domain** | **string** |  | 
+ **type_** | **string** |  | 
+ **name** | **string** |  | 
+ **scope** | **map[string]map[string]string** | Optional scope key/value pairs identifying the entity (scope[key]&#x3D;value). | 
+ **xScopeOrgID** | **string** | Grafana Tenant/Stack ID | 
 
 ### Return type
 
@@ -111,15 +111,15 @@ import (
 
 func main() {
 	namespace := "namespace_example" // string | Tenant namespace, formatted as stacks-<stackId> (default to "")
-	type_ := "type__example" // string |
-	fromDomain := "fromDomain_example" // string |
-	fromType := "fromType_example" // string |
-	fromName := "fromName_example" // string |
-	toDomain := "toDomain_example" // string |
-	toType := "toType_example" // string |
-	toName := "toName_example" // string |
-	fromScope := map[string]string{"env": "prod"} // map[string]string | Optional scope key/value pairs identifying the 'from' entity (from.scope[key]=value). (optional)
-	toScope := map[string]string{"env": "prod"} // map[string]string | Optional scope key/value pairs identifying the 'to' entity (to.scope[key]=value). (optional)
+	type_ := "type__example" // string | 
+	fromDomain := "fromDomain_example" // string | 
+	fromType := "fromType_example" // string | 
+	fromName := "fromName_example" // string | 
+	toDomain := "toDomain_example" // string | 
+	toType := "toType_example" // string | 
+	toName := "toName_example" // string | 
+	fromScope := map[string]string{"key": map[string]string{"key": "Inner_example"}} // map[string]string | Optional scope key/value pairs identifying the 'from' entity (from.scope[key]=value). (optional)
+	toScope := map[string]string{"key": map[string]string{"key": "Inner_example"}} // map[string]string | Optional scope key/value pairs identifying the 'to' entity (to.scope[key]=value). (optional)
 	xScopeOrgID := "2944" // string | Grafana Tenant/Stack ID (optional)
 
 	configuration := openapiclient.NewConfiguration()
@@ -148,16 +148,16 @@ Other parameters are passed through a pointer to a apiDeleteRelationshipRequest 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 
- **type_** | **string** |  |
- **fromDomain** | **string** |  |
- **fromType** | **string** |  |
- **fromName** | **string** |  |
- **toDomain** | **string** |  |
- **toType** | **string** |  |
- **toName** | **string** |  |
- **fromScope** | **map[string]string** | Optional scope key/value pairs identifying the &#39;from&#39; entity (from.scope[key]&#x3D;value). |
- **toScope** | **map[string]string** | Optional scope key/value pairs identifying the &#39;to&#39; entity (to.scope[key]&#x3D;value). |
- **xScopeOrgID** | **string** | Grafana Tenant/Stack ID |
+ **type_** | **string** |  | 
+ **fromDomain** | **string** |  | 
+ **fromType** | **string** |  | 
+ **fromName** | **string** |  | 
+ **toDomain** | **string** |  | 
+ **toType** | **string** |  | 
+ **toName** | **string** |  | 
+ **fromScope** | **map[string]map[string]string** | Optional scope key/value pairs identifying the &#39;from&#39; entity (from.scope[key]&#x3D;value). | 
+ **toScope** | **map[string]map[string]string** | Optional scope key/value pairs identifying the &#39;to&#39; entity (to.scope[key]&#x3D;value). | 
+ **xScopeOrgID** | **string** | Grafana Tenant/Stack ID | 
 
 ### Return type
 
@@ -199,7 +199,7 @@ import (
 
 func main() {
 	namespace := "namespace_example" // string | Tenant namespace, formatted as stacks-<stackId>; must match the request tenant (default to "")
-	entityWriteRequestDto := *openapiclient.NewEntityWriteRequestDto("Domain_example", "Type_example", "Name_example", int64(-1)) // EntityWriteRequestDto |
+	entityWriteRequestDto := *openapiclient.NewEntityWriteRequestDto("Domain_example", "Type_example", "Name_example", int64(-1)) // EntityWriteRequestDto | 
 	xScopeOrgID := "2944" // string | Grafana Tenant/Stack ID (optional)
 
 	configuration := openapiclient.NewConfiguration()
@@ -230,8 +230,8 @@ Other parameters are passed through a pointer to a apiUpsertEntityRequest struct
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 
- **entityWriteRequestDto** | [**EntityWriteRequestDto**](EntityWriteRequestDto.md) |  |
- **xScopeOrgID** | **string** | Grafana Tenant/Stack ID |
+ **entityWriteRequestDto** | [**EntityWriteRequestDto**](EntityWriteRequestDto.md) |  | 
+ **xScopeOrgID** | **string** | Grafana Tenant/Stack ID | 
 
 ### Return type
 
@@ -273,7 +273,7 @@ import (
 
 func main() {
 	namespace := "namespace_example" // string | Tenant namespace, formatted as stacks-<stackId> (default to "")
-	relationshipWriteRequestDto := *openapiclient.NewRelationshipWriteRequestDto("Domain_example", "Type_example", *openapiclient.NewEntityRefDto("Domain_example", "Type_example", "Name_example"), *openapiclient.NewEntityRefDto("Domain_example", "Type_example", "Name_example"), int64(-1)) // RelationshipWriteRequestDto |
+	relationshipWriteRequestDto := *openapiclient.NewRelationshipWriteRequestDto("Domain_example", "Type_example", *openapiclient.NewEntityRefDto("Domain_example", "Type_example", "Name_example"), *openapiclient.NewEntityRefDto("Domain_example", "Type_example", "Name_example"), int64(-1)) // RelationshipWriteRequestDto | 
 	xScopeOrgID := "2944" // string | Grafana Tenant/Stack ID (optional)
 
 	configuration := openapiclient.NewConfiguration()
@@ -304,8 +304,8 @@ Other parameters are passed through a pointer to a apiUpsertRelationshipRequest 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 
- **relationshipWriteRequestDto** | [**RelationshipWriteRequestDto**](RelationshipWriteRequestDto.md) |  |
- **xScopeOrgID** | **string** | Grafana Tenant/Stack ID |
+ **relationshipWriteRequestDto** | [**RelationshipWriteRequestDto**](RelationshipWriteRequestDto.md) |  | 
+ **xScopeOrgID** | **string** | Grafana Tenant/Stack ID | 
 
 ### Return type
 

--- a/go/kgwrite/docs/KnowledgeGraphWriteAPIAPI.md
+++ b/go/kgwrite/docs/KnowledgeGraphWriteAPIAPI.md
@@ -33,10 +33,10 @@ import (
 
 func main() {
 	namespace := "namespace_example" // string | Tenant namespace, formatted as stacks-<stackId> (default to "")
-	domain := "domain_example" // string | 
-	type_ := "type__example" // string | 
-	name := "name_example" // string | 
-	scope := map[string]string{"key": map[string]string{"key": "Inner_example"}} // map[string]string | Optional scope key/value pairs identifying the entity (scope[key]=value). (optional)
+	domain := "domain_example" // string |
+	type_ := "type__example" // string |
+	name := "name_example" // string |
+	scope := map[string]string{"env": "prod"} // map[string]string | Optional scope key/value pairs identifying the entity (scope[key]=value). (optional)
 	xScopeOrgID := "2944" // string | Grafana Tenant/Stack ID (optional)
 
 	configuration := openapiclient.NewConfiguration()
@@ -65,11 +65,11 @@ Other parameters are passed through a pointer to a apiDeleteEntityRequest struct
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 
- **domain** | **string** |  | 
- **type_** | **string** |  | 
- **name** | **string** |  | 
- **scope** | **map[string]map[string]string** | Optional scope key/value pairs identifying the entity (scope[key]&#x3D;value). | 
- **xScopeOrgID** | **string** | Grafana Tenant/Stack ID | 
+ **domain** | **string** |  |
+ **type_** | **string** |  |
+ **name** | **string** |  |
+ **scope** | **map[string]string** | Optional scope key/value pairs identifying the entity (scope[key]&#x3D;value). |
+ **xScopeOrgID** | **string** | Grafana Tenant/Stack ID |
 
 ### Return type
 
@@ -111,15 +111,15 @@ import (
 
 func main() {
 	namespace := "namespace_example" // string | Tenant namespace, formatted as stacks-<stackId> (default to "")
-	type_ := "type__example" // string | 
-	fromDomain := "fromDomain_example" // string | 
-	fromType := "fromType_example" // string | 
-	fromName := "fromName_example" // string | 
-	toDomain := "toDomain_example" // string | 
-	toType := "toType_example" // string | 
-	toName := "toName_example" // string | 
-	fromScope := map[string]string{"key": map[string]string{"key": "Inner_example"}} // map[string]string | Optional scope key/value pairs identifying the 'from' entity (from.scope[key]=value). (optional)
-	toScope := map[string]string{"key": map[string]string{"key": "Inner_example"}} // map[string]string | Optional scope key/value pairs identifying the 'to' entity (to.scope[key]=value). (optional)
+	type_ := "type__example" // string |
+	fromDomain := "fromDomain_example" // string |
+	fromType := "fromType_example" // string |
+	fromName := "fromName_example" // string |
+	toDomain := "toDomain_example" // string |
+	toType := "toType_example" // string |
+	toName := "toName_example" // string |
+	fromScope := map[string]string{"env": "prod"} // map[string]string | Optional scope key/value pairs identifying the 'from' entity (from.scope[key]=value). (optional)
+	toScope := map[string]string{"env": "prod"} // map[string]string | Optional scope key/value pairs identifying the 'to' entity (to.scope[key]=value). (optional)
 	xScopeOrgID := "2944" // string | Grafana Tenant/Stack ID (optional)
 
 	configuration := openapiclient.NewConfiguration()
@@ -148,16 +148,16 @@ Other parameters are passed through a pointer to a apiDeleteRelationshipRequest 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 
- **type_** | **string** |  | 
- **fromDomain** | **string** |  | 
- **fromType** | **string** |  | 
- **fromName** | **string** |  | 
- **toDomain** | **string** |  | 
- **toType** | **string** |  | 
- **toName** | **string** |  | 
- **fromScope** | **map[string]map[string]string** | Optional scope key/value pairs identifying the &#39;from&#39; entity (from.scope[key]&#x3D;value). | 
- **toScope** | **map[string]map[string]string** | Optional scope key/value pairs identifying the &#39;to&#39; entity (to.scope[key]&#x3D;value). | 
- **xScopeOrgID** | **string** | Grafana Tenant/Stack ID | 
+ **type_** | **string** |  |
+ **fromDomain** | **string** |  |
+ **fromType** | **string** |  |
+ **fromName** | **string** |  |
+ **toDomain** | **string** |  |
+ **toType** | **string** |  |
+ **toName** | **string** |  |
+ **fromScope** | **map[string]string** | Optional scope key/value pairs identifying the &#39;from&#39; entity (from.scope[key]&#x3D;value). |
+ **toScope** | **map[string]string** | Optional scope key/value pairs identifying the &#39;to&#39; entity (to.scope[key]&#x3D;value). |
+ **xScopeOrgID** | **string** | Grafana Tenant/Stack ID |
 
 ### Return type
 
@@ -199,7 +199,7 @@ import (
 
 func main() {
 	namespace := "namespace_example" // string | Tenant namespace, formatted as stacks-<stackId>; must match the request tenant (default to "")
-	entityWriteRequestDto := *openapiclient.NewEntityWriteRequestDto("Domain_example", "Type_example", "Name_example", int64(-1)) // EntityWriteRequestDto | 
+	entityWriteRequestDto := *openapiclient.NewEntityWriteRequestDto("Domain_example", "Type_example", "Name_example", int64(-1)) // EntityWriteRequestDto |
 	xScopeOrgID := "2944" // string | Grafana Tenant/Stack ID (optional)
 
 	configuration := openapiclient.NewConfiguration()
@@ -230,8 +230,8 @@ Other parameters are passed through a pointer to a apiUpsertEntityRequest struct
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 
- **entityWriteRequestDto** | [**EntityWriteRequestDto**](EntityWriteRequestDto.md) |  | 
- **xScopeOrgID** | **string** | Grafana Tenant/Stack ID | 
+ **entityWriteRequestDto** | [**EntityWriteRequestDto**](EntityWriteRequestDto.md) |  |
+ **xScopeOrgID** | **string** | Grafana Tenant/Stack ID |
 
 ### Return type
 
@@ -273,7 +273,7 @@ import (
 
 func main() {
 	namespace := "namespace_example" // string | Tenant namespace, formatted as stacks-<stackId> (default to "")
-	relationshipWriteRequestDto := *openapiclient.NewRelationshipWriteRequestDto("Domain_example", "Type_example", *openapiclient.NewEntityRefDto("Domain_example", "Type_example", "Name_example"), *openapiclient.NewEntityRefDto("Domain_example", "Type_example", "Name_example"), int64(-1)) // RelationshipWriteRequestDto | 
+	relationshipWriteRequestDto := *openapiclient.NewRelationshipWriteRequestDto("Domain_example", "Type_example", *openapiclient.NewEntityRefDto("Domain_example", "Type_example", "Name_example"), *openapiclient.NewEntityRefDto("Domain_example", "Type_example", "Name_example"), int64(-1)) // RelationshipWriteRequestDto |
 	xScopeOrgID := "2944" // string | Grafana Tenant/Stack ID (optional)
 
 	configuration := openapiclient.NewConfiguration()
@@ -304,8 +304,8 @@ Other parameters are passed through a pointer to a apiUpsertRelationshipRequest 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 
- **relationshipWriteRequestDto** | [**RelationshipWriteRequestDto**](RelationshipWriteRequestDto.md) |  | 
- **xScopeOrgID** | **string** | Grafana Tenant/Stack ID | 
+ **relationshipWriteRequestDto** | [**RelationshipWriteRequestDto**](RelationshipWriteRequestDto.md) |  |
+ **xScopeOrgID** | **string** | Grafana Tenant/Stack ID |
 
 ### Return type
 

--- a/go/kgwrite/docs/KnowledgeGraphWriteAPIAPI.md
+++ b/go/kgwrite/docs/KnowledgeGraphWriteAPIAPI.md
@@ -4,8 +4,8 @@ All URIs are relative to *http://localhost:8030/api-server*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**DeleteEntity**](KnowledgeGraphWriteAPIAPI.md#DeleteEntity) | **Delete** /apis/kg.grafana.com/v1alpha1/namespaces/{namespace}/entities/{type}/{name} | Delete a custom entity
-[**DeleteRelationship**](KnowledgeGraphWriteAPIAPI.md#DeleteRelationship) | **Delete** /apis/kg.grafana.com/v1alpha1/namespaces/{namespace}/relationships/{type} | Delete a custom relationship
+[**DeleteEntity**](KnowledgeGraphWriteAPIAPI.md#DeleteEntity) | **Delete** /apis/kg.grafana.com/v1alpha1/namespaces/{namespace}/entities | Delete a custom entity
+[**DeleteRelationship**](KnowledgeGraphWriteAPIAPI.md#DeleteRelationship) | **Delete** /apis/kg.grafana.com/v1alpha1/namespaces/{namespace}/relationships | Delete a custom relationship
 [**UpsertEntity**](KnowledgeGraphWriteAPIAPI.md#UpsertEntity) | **Post** /apis/kg.grafana.com/v1alpha1/namespaces/{namespace}/entities | Create or update a custom entity
 [**UpsertRelationship**](KnowledgeGraphWriteAPIAPI.md#UpsertRelationship) | **Post** /apis/kg.grafana.com/v1alpha1/namespaces/{namespace}/relationships | Create or update a custom relationship
 
@@ -13,7 +13,7 @@ Method | HTTP request | Description
 
 ## DeleteEntity
 
-> DeleteEntity(ctx, namespace, type_, name).Domain(domain).Scope(scope).XScopeOrgID(xScopeOrgID).Execute()
+> DeleteEntity(ctx, namespace).Domain(domain).Type_(type_).Name(name).Scope(scope).XScopeOrgID(xScopeOrgID).Execute()
 
 Delete a custom entity
 
@@ -33,15 +33,15 @@ import (
 
 func main() {
 	namespace := "namespace_example" // string | Tenant namespace, formatted as stacks-<stackId> (default to "")
-	type_ := "type__example" // string | Entity type (default to "")
-	name := "name_example" // string | Entity name (default to "")
-	domain := "domain_example" // string | 
+	domain := "domain_example" // string |
+	type_ := "type__example" // string |
+	name := "name_example" // string |
 	scope := map[string]string{"key": map[string]string{"key": "Inner_example"}} // map[string]string | Optional scope key/value pairs identifying the entity (scope[key]=value). (optional)
 	xScopeOrgID := "2944" // string | Grafana Tenant/Stack ID (optional)
 
 	configuration := openapiclient.NewConfiguration()
 	apiClient := openapiclient.NewAPIClient(configuration)
-	r, err := apiClient.KnowledgeGraphWriteAPIAPI.DeleteEntity(context.Background(), namespace, type_, name).Domain(domain).Scope(scope).XScopeOrgID(xScopeOrgID).Execute()
+	r, err := apiClient.KnowledgeGraphWriteAPIAPI.DeleteEntity(context.Background(), namespace).Domain(domain).Type_(type_).Name(name).Scope(scope).XScopeOrgID(xScopeOrgID).Execute()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error when calling `KnowledgeGraphWriteAPIAPI.DeleteEntity``: %v\n", err)
 		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
@@ -56,8 +56,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
 **namespace** | **string** | Tenant namespace, formatted as stacks-&lt;stackId&gt; | [default to &quot;&quot;]
-**type_** | **string** | Entity type | [default to &quot;&quot;]
-**name** | **string** | Entity name | [default to &quot;&quot;]
 
 ### Other Parameters
 
@@ -67,11 +65,11 @@ Other parameters are passed through a pointer to a apiDeleteEntityRequest struct
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 
-
-
- **domain** | **string** |  | 
- **scope** | **map[string]map[string]string** | Optional scope key/value pairs identifying the entity (scope[key]&#x3D;value). | 
- **xScopeOrgID** | **string** | Grafana Tenant/Stack ID | 
+ **domain** | **string** |  |
+ **type_** | **string** |  |
+ **name** | **string** |  |
+ **scope** | **map[string]map[string]string** | Optional scope key/value pairs identifying the entity (scope[key]&#x3D;value). |
+ **xScopeOrgID** | **string** | Grafana Tenant/Stack ID |
 
 ### Return type
 
@@ -93,7 +91,7 @@ No authorization required
 
 ## DeleteRelationship
 
-> DeleteRelationship(ctx, namespace, type_).FromDomain(fromDomain).FromType(fromType).FromName(fromName).ToDomain(toDomain).ToType(toType).ToName(toName).FromScope(fromScope).ToScope(toScope).XScopeOrgID(xScopeOrgID).Execute()
+> DeleteRelationship(ctx, namespace).Type_(type_).FromDomain(fromDomain).FromType(fromType).FromName(fromName).ToDomain(toDomain).ToType(toType).ToName(toName).FromScope(fromScope).ToScope(toScope).XScopeOrgID(xScopeOrgID).Execute()
 
 Delete a custom relationship
 
@@ -113,20 +111,20 @@ import (
 
 func main() {
 	namespace := "namespace_example" // string | Tenant namespace, formatted as stacks-<stackId> (default to "")
-	type_ := "type__example" // string | Relationship type (default to "")
-	fromDomain := "fromDomain_example" // string | 
-	fromType := "fromType_example" // string | 
-	fromName := "fromName_example" // string | 
-	toDomain := "toDomain_example" // string | 
-	toType := "toType_example" // string | 
-	toName := "toName_example" // string | 
+	type_ := "type__example" // string |
+	fromDomain := "fromDomain_example" // string |
+	fromType := "fromType_example" // string |
+	fromName := "fromName_example" // string |
+	toDomain := "toDomain_example" // string |
+	toType := "toType_example" // string |
+	toName := "toName_example" // string |
 	fromScope := map[string]string{"key": map[string]string{"key": "Inner_example"}} // map[string]string | Optional scope key/value pairs identifying the 'from' entity (from.scope[key]=value). (optional)
 	toScope := map[string]string{"key": map[string]string{"key": "Inner_example"}} // map[string]string | Optional scope key/value pairs identifying the 'to' entity (to.scope[key]=value). (optional)
 	xScopeOrgID := "2944" // string | Grafana Tenant/Stack ID (optional)
 
 	configuration := openapiclient.NewConfiguration()
 	apiClient := openapiclient.NewAPIClient(configuration)
-	r, err := apiClient.KnowledgeGraphWriteAPIAPI.DeleteRelationship(context.Background(), namespace, type_).FromDomain(fromDomain).FromType(fromType).FromName(fromName).ToDomain(toDomain).ToType(toType).ToName(toName).FromScope(fromScope).ToScope(toScope).XScopeOrgID(xScopeOrgID).Execute()
+	r, err := apiClient.KnowledgeGraphWriteAPIAPI.DeleteRelationship(context.Background(), namespace).Type_(type_).FromDomain(fromDomain).FromType(fromType).FromName(fromName).ToDomain(toDomain).ToType(toType).ToName(toName).FromScope(fromScope).ToScope(toScope).XScopeOrgID(xScopeOrgID).Execute()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error when calling `KnowledgeGraphWriteAPIAPI.DeleteRelationship``: %v\n", err)
 		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
@@ -141,7 +139,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
 **namespace** | **string** | Tenant namespace, formatted as stacks-&lt;stackId&gt; | [default to &quot;&quot;]
-**type_** | **string** | Relationship type | [default to &quot;&quot;]
 
 ### Other Parameters
 
@@ -151,16 +148,16 @@ Other parameters are passed through a pointer to a apiDeleteRelationshipRequest 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 
-
- **fromDomain** | **string** |  | 
- **fromType** | **string** |  | 
- **fromName** | **string** |  | 
- **toDomain** | **string** |  | 
- **toType** | **string** |  | 
- **toName** | **string** |  | 
- **fromScope** | **map[string]map[string]string** | Optional scope key/value pairs identifying the &#39;from&#39; entity (from.scope[key]&#x3D;value). | 
- **toScope** | **map[string]map[string]string** | Optional scope key/value pairs identifying the &#39;to&#39; entity (to.scope[key]&#x3D;value). | 
- **xScopeOrgID** | **string** | Grafana Tenant/Stack ID | 
+ **type_** | **string** |  |
+ **fromDomain** | **string** |  |
+ **fromType** | **string** |  |
+ **fromName** | **string** |  |
+ **toDomain** | **string** |  |
+ **toType** | **string** |  |
+ **toName** | **string** |  |
+ **fromScope** | **map[string]map[string]string** | Optional scope key/value pairs identifying the &#39;from&#39; entity (from.scope[key]&#x3D;value). |
+ **toScope** | **map[string]map[string]string** | Optional scope key/value pairs identifying the &#39;to&#39; entity (to.scope[key]&#x3D;value). |
+ **xScopeOrgID** | **string** | Grafana Tenant/Stack ID |
 
 ### Return type
 
@@ -202,7 +199,7 @@ import (
 
 func main() {
 	namespace := "namespace_example" // string | Tenant namespace, formatted as stacks-<stackId>; must match the request tenant (default to "")
-	entityWriteRequestDto := *openapiclient.NewEntityWriteRequestDto("Domain_example", "Type_example", "Name_example", int64(-1)) // EntityWriteRequestDto | 
+	entityWriteRequestDto := *openapiclient.NewEntityWriteRequestDto("Domain_example", "Type_example", "Name_example", int64(-1)) // EntityWriteRequestDto |
 	xScopeOrgID := "2944" // string | Grafana Tenant/Stack ID (optional)
 
 	configuration := openapiclient.NewConfiguration()
@@ -233,8 +230,8 @@ Other parameters are passed through a pointer to a apiUpsertEntityRequest struct
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 
- **entityWriteRequestDto** | [**EntityWriteRequestDto**](EntityWriteRequestDto.md) |  | 
- **xScopeOrgID** | **string** | Grafana Tenant/Stack ID | 
+ **entityWriteRequestDto** | [**EntityWriteRequestDto**](EntityWriteRequestDto.md) |  |
+ **xScopeOrgID** | **string** | Grafana Tenant/Stack ID |
 
 ### Return type
 
@@ -276,7 +273,7 @@ import (
 
 func main() {
 	namespace := "namespace_example" // string | Tenant namespace, formatted as stacks-<stackId> (default to "")
-	relationshipWriteRequestDto := *openapiclient.NewRelationshipWriteRequestDto("Domain_example", "Type_example", *openapiclient.NewEntityRefDto("Domain_example", "Type_example", "Name_example"), *openapiclient.NewEntityRefDto("Domain_example", "Type_example", "Name_example"), int64(-1)) // RelationshipWriteRequestDto | 
+	relationshipWriteRequestDto := *openapiclient.NewRelationshipWriteRequestDto("Domain_example", "Type_example", *openapiclient.NewEntityRefDto("Domain_example", "Type_example", "Name_example"), *openapiclient.NewEntityRefDto("Domain_example", "Type_example", "Name_example"), int64(-1)) // RelationshipWriteRequestDto |
 	xScopeOrgID := "2944" // string | Grafana Tenant/Stack ID (optional)
 
 	configuration := openapiclient.NewConfiguration()
@@ -307,8 +304,8 @@ Other parameters are passed through a pointer to a apiUpsertRelationshipRequest 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 
- **relationshipWriteRequestDto** | [**RelationshipWriteRequestDto**](RelationshipWriteRequestDto.md) |  | 
- **xScopeOrgID** | **string** | Grafana Tenant/Stack ID | 
+ **relationshipWriteRequestDto** | [**RelationshipWriteRequestDto**](RelationshipWriteRequestDto.md) |  |
+ **xScopeOrgID** | **string** | Grafana Tenant/Stack ID |
 
 ### Return type
 

--- a/go/kgwrite/test/api_knowledge_graph_write_api_test.go
+++ b/go/kgwrite/test/api_knowledge_graph_write_api_test.go
@@ -28,10 +28,8 @@ func Test_kgwrite_KnowledgeGraphWriteAPIAPIService(t *testing.T) {
 		t.Skip("skip test") // remove to run test
 
 		var namespace string
-		var type_ string
-		var name string
 
-		httpRes, err := apiClient.KnowledgeGraphWriteAPIAPI.DeleteEntity(context.Background(), namespace, type_, name).Execute()
+		httpRes, err := apiClient.KnowledgeGraphWriteAPIAPI.DeleteEntity(context.Background(), namespace).Execute()
 
 		require.Nil(t, err)
 		assert.Equal(t, 200, httpRes.StatusCode)
@@ -43,9 +41,8 @@ func Test_kgwrite_KnowledgeGraphWriteAPIAPIService(t *testing.T) {
 		t.Skip("skip test") // remove to run test
 
 		var namespace string
-		var type_ string
 
-		httpRes, err := apiClient.KnowledgeGraphWriteAPIAPI.DeleteRelationship(context.Background(), namespace, type_).Execute()
+		httpRes, err := apiClient.KnowledgeGraphWriteAPIAPI.DeleteRelationship(context.Background(), namespace).Execute()
 
 		require.Nil(t, err)
 		assert.Equal(t, 200, httpRes.StatusCode)

--- a/go/kgwrite/test/api_knowledge_graph_write_api_test.go
+++ b/go/kgwrite/test/api_knowledge_graph_write_api_test.go
@@ -28,11 +28,18 @@ func Test_kgwrite_KnowledgeGraphWriteAPIAPIService(t *testing.T) {
 		t.Skip("skip test") // remove to run test
 
 		var namespace string
+		var domain string
+		var type_ string
+		var name string
 
-		httpRes, err := apiClient.KnowledgeGraphWriteAPIAPI.DeleteEntity(context.Background(), namespace).Execute()
+		httpRes, err := apiClient.KnowledgeGraphWriteAPIAPI.DeleteEntity(context.Background(), namespace).
+			Domain(domain).
+			Type_(type_).
+			Name(name).
+			Execute()
 
 		require.Nil(t, err)
-		assert.Equal(t, 200, httpRes.StatusCode)
+		assert.Equal(t, 204, httpRes.StatusCode)
 
 	})
 
@@ -41,11 +48,26 @@ func Test_kgwrite_KnowledgeGraphWriteAPIAPIService(t *testing.T) {
 		t.Skip("skip test") // remove to run test
 
 		var namespace string
+		var type_ string
+		var fromDomain string
+		var fromType string
+		var fromName string
+		var toDomain string
+		var toType string
+		var toName string
 
-		httpRes, err := apiClient.KnowledgeGraphWriteAPIAPI.DeleteRelationship(context.Background(), namespace).Execute()
+		httpRes, err := apiClient.KnowledgeGraphWriteAPIAPI.DeleteRelationship(context.Background(), namespace).
+			Type_(type_).
+			FromDomain(fromDomain).
+			FromType(fromType).
+			FromName(fromName).
+			ToDomain(toDomain).
+			ToType(toType).
+			ToName(toName).
+			Execute()
 
 		require.Nil(t, err)
-		assert.Equal(t, 200, httpRes.StatusCode)
+		assert.Equal(t, 204, httpRes.StatusCode)
 
 	})
 

--- a/go/kgwrite/test/api_knowledge_graph_write_api_test.go
+++ b/go/kgwrite/test/api_knowledge_graph_write_api_test.go
@@ -28,18 +28,11 @@ func Test_kgwrite_KnowledgeGraphWriteAPIAPIService(t *testing.T) {
 		t.Skip("skip test") // remove to run test
 
 		var namespace string
-		var domain string
-		var type_ string
-		var name string
 
-		httpRes, err := apiClient.KnowledgeGraphWriteAPIAPI.DeleteEntity(context.Background(), namespace).
-			Domain(domain).
-			Type_(type_).
-			Name(name).
-			Execute()
+		httpRes, err := apiClient.KnowledgeGraphWriteAPIAPI.DeleteEntity(context.Background(), namespace).Execute()
 
 		require.Nil(t, err)
-		assert.Equal(t, 204, httpRes.StatusCode)
+		assert.Equal(t, 200, httpRes.StatusCode)
 
 	})
 
@@ -48,26 +41,11 @@ func Test_kgwrite_KnowledgeGraphWriteAPIAPIService(t *testing.T) {
 		t.Skip("skip test") // remove to run test
 
 		var namespace string
-		var type_ string
-		var fromDomain string
-		var fromType string
-		var fromName string
-		var toDomain string
-		var toType string
-		var toName string
 
-		httpRes, err := apiClient.KnowledgeGraphWriteAPIAPI.DeleteRelationship(context.Background(), namespace).
-			Type_(type_).
-			FromDomain(fromDomain).
-			FromType(fromType).
-			FromName(fromName).
-			ToDomain(toDomain).
-			ToType(toType).
-			ToName(toName).
-			Execute()
+		httpRes, err := apiClient.KnowledgeGraphWriteAPIAPI.DeleteRelationship(context.Background(), namespace).Execute()
 
 		require.Nil(t, err)
-		assert.Equal(t, 204, httpRes.StatusCode)
+		assert.Equal(t, 200, httpRes.StatusCode)
 
 	})
 

--- a/kg-write-openapi.yaml
+++ b/kg-write-openapi.yaml
@@ -116,6 +116,139 @@ paths:
             application/x-yaml:
               schema:
                 $ref: "#/components/schemas/ApiError"
+    delete:
+      tags:
+        - Knowledge Graph Write API
+      summary: Delete a custom relationship
+      description: "Deletes an API-origin edge between the from/to entities. The relationship coordinates travel as query params (no request body): type, plus from.domain/from.type/from.name (+ from.scope[key]=value) and the matching to.* params. Putting type in the query string matches the entity DELETE shape on the collection path."
+      operationId: deleteRelationship
+      parameters:
+        - name: namespace
+          in: path
+          description: "Tenant namespace, formatted as stacks-<stackId>"
+          required: true
+          schema:
+            type: string
+            default: ""
+        - name: type
+          in: query
+          required: true
+          schema:
+            type: string
+            minLength: 1
+            pattern: "^[A-Za-z][A-Za-z0-9_]*$"
+        - name: from.domain
+          in: query
+          required: true
+          schema:
+            type: string
+            minLength: 1
+            pattern: "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$"
+        - name: from.type
+          in: query
+          required: true
+          schema:
+            type: string
+            minLength: 1
+            pattern: "^[A-Za-z][A-Za-z0-9_]*$"
+        - name: from.name
+          in: query
+          required: true
+          schema:
+            type: string
+            minLength: 1
+        - name: to.domain
+          in: query
+          required: true
+          schema:
+            type: string
+            minLength: 1
+            pattern: "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$"
+        - name: to.type
+          in: query
+          required: true
+          schema:
+            type: string
+            minLength: 1
+            pattern: "^[A-Za-z][A-Za-z0-9_]*$"
+        - name: to.name
+          in: query
+          required: true
+          schema:
+            type: string
+            minLength: 1
+        - name: from.scope
+          in: query
+          description: "Optional scope key/value pairs identifying the 'from' entity (from.scope[key]=value)."
+          required: false
+          style: deepObject
+          explode: true
+          schema:
+            type: object
+            additionalProperties:
+              type: string
+        - name: to.scope
+          in: query
+          description: "Optional scope key/value pairs identifying the 'to' entity (to.scope[key]=value)."
+          required: false
+          style: deepObject
+          explode: true
+          schema:
+            type: object
+            additionalProperties:
+              type: string
+        - $ref: "#/components/parameters/TenantId"
+      responses:
+        "204":
+          description: Relationship deleted
+        "400":
+          description: Missing tenant context or malformed namespace
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+            application/x-yml:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+            application/x-yaml:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "403":
+          description: "Namespace does not match the request tenant, or edge is not API-origin"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+            application/x-yml:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+            application/x-yaml:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "404":
+          description: Relationship not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+            application/x-yml:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+            application/x-yaml:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "422":
+          description: Query params failed validation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+            application/x-yml:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+            application/x-yaml:
+              schema:
+                $ref: "#/components/schemas/ApiError"
   /apis/kg.grafana.com/v1alpha1/namespaces/{namespace}/entities:
     post:
       tags:
@@ -217,167 +350,16 @@ paths:
             application/x-yaml:
               schema:
                 $ref: "#/components/schemas/ApiError"
-  /apis/kg.grafana.com/v1alpha1/namespaces/{namespace}/relationships/{type}:
-    delete:
-      tags:
-        - Knowledge Graph Write API
-      summary: Delete a custom relationship
-      description: "Deletes an API-origin edge of the given type between the from/to entities. The endpoint coordinates travel as query params (no request body): from.domain/from.type/from.name (+ from.scope[key]=value) and the matching to.* params."
-      operationId: deleteRelationship
-      parameters:
-        - name: namespace
-          in: path
-          description: "Tenant namespace, formatted as stacks-<stackId>"
-          required: true
-          schema:
-            type: string
-            default: ""
-        - name: type
-          in: path
-          description: Relationship type
-          required: true
-          schema:
-            type: string
-            default: ""
-            pattern: "^[A-Za-z][A-Za-z0-9_]*$"
-        - name: from.domain
-          in: query
-          required: true
-          schema:
-            type: string
-            minLength: 1
-            pattern: "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$"
-        - name: from.type
-          in: query
-          required: true
-          schema:
-            type: string
-            minLength: 1
-            pattern: "^[A-Za-z][A-Za-z0-9_]*$"
-        - name: from.name
-          in: query
-          required: true
-          schema:
-            type: string
-            minLength: 1
-        - name: to.domain
-          in: query
-          required: true
-          schema:
-            type: string
-            minLength: 1
-            pattern: "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$"
-        - name: to.type
-          in: query
-          required: true
-          schema:
-            type: string
-            minLength: 1
-            pattern: "^[A-Za-z][A-Za-z0-9_]*$"
-        - name: to.name
-          in: query
-          required: true
-          schema:
-            type: string
-            minLength: 1
-        - name: from.scope
-          in: query
-          description: "Optional scope key/value pairs identifying the 'from' entity (from.scope[key]=value)."
-          required: false
-          style: deepObject
-          explode: true
-          schema:
-            type: object
-            additionalProperties:
-              type: string
-        - name: to.scope
-          in: query
-          description: "Optional scope key/value pairs identifying the 'to' entity (to.scope[key]=value)."
-          required: false
-          style: deepObject
-          explode: true
-          schema:
-            type: object
-            additionalProperties:
-              type: string
-        - $ref: "#/components/parameters/TenantId"
-      responses:
-        "204":
-          description: Relationship deleted
-        "400":
-          description: "Missing tenant context, malformed namespace, or invalid relationship type"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ApiError"
-            application/x-yml:
-              schema:
-                $ref: "#/components/schemas/ApiError"
-            application/x-yaml:
-              schema:
-                $ref: "#/components/schemas/ApiError"
-        "403":
-          description: "Namespace does not match the request tenant, or edge is not API-origin"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ApiError"
-            application/x-yml:
-              schema:
-                $ref: "#/components/schemas/ApiError"
-            application/x-yaml:
-              schema:
-                $ref: "#/components/schemas/ApiError"
-        "404":
-          description: Relationship not found
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ApiError"
-            application/x-yml:
-              schema:
-                $ref: "#/components/schemas/ApiError"
-            application/x-yaml:
-              schema:
-                $ref: "#/components/schemas/ApiError"
-        "422":
-          description: "Query params failed validation, or the relationship type path variable is invalid"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ApiError"
-            application/x-yml:
-              schema:
-                $ref: "#/components/schemas/ApiError"
-            application/x-yaml:
-              schema:
-                $ref: "#/components/schemas/ApiError"
-  /apis/kg.grafana.com/v1alpha1/namespaces/{namespace}/entities/{type}/{name}:
     delete:
       tags:
         - Knowledge Graph Write API
       summary: Delete a custom entity
-      description: "Deletes an API-origin entity; only _origin=api objects may be deleted. The entity coordinates travel as query params (no request body): the top-level 'domain' control param plus an optional nested scope map (scope[key]=value)."
+      description: "Deletes an API-origin entity; only _origin=api objects may be deleted. The entity coordinates travel as query params (no request body): domain, type, and name, plus an optional nested scope map (scope[key]=value). Putting name in the query string (not the path) allows names that contain '/'."
       operationId: deleteEntity
       parameters:
         - name: namespace
           in: path
           description: "Tenant namespace, formatted as stacks-<stackId>"
-          required: true
-          schema:
-            type: string
-            default: ""
-        - name: type
-          in: path
-          description: Entity type
-          required: true
-          schema:
-            type: string
-            default: ""
-            pattern: "^[A-Za-z][A-Za-z0-9_]*$"
-        - name: name
-          in: path
-          description: Entity name
           required: true
           schema:
             type: string
@@ -389,6 +371,19 @@ paths:
             type: string
             minLength: 1
             pattern: "^(?!kg$)[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$"
+        - name: type
+          in: query
+          required: true
+          schema:
+            type: string
+            minLength: 1
+            pattern: "^[A-Za-z][A-Za-z0-9_]*$"
+        - name: name
+          in: query
+          required: true
+          schema:
+            type: string
+            minLength: 1
         - name: scope
           in: query
           description: "Optional scope key/value pairs identifying the entity (scope[key]=value)."
@@ -440,7 +435,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ApiError"
         "422":
-          description: "Query params failed validation, or the entity type path variable is invalid"
+          description: Query params failed validation
           content:
             application/json:
               schema:
@@ -497,9 +492,7 @@ components:
         ttlSeconds:
           type: integer
           format: int64
-          description: Time-to-live in seconds. Positive values expire the relationship
-            after that many seconds, 0 expires it immediately, and negative values mean
-            no expiry.
+          description: "Time-to-live in seconds. Positive values expire the relationship after that many seconds, 0 expires it immediately, and negative values mean no expiry."
           example: -1
       required:
         - domain
@@ -585,8 +578,7 @@ components:
         ttlSeconds:
           type: integer
           format: int64
-          description: Time-to-live in seconds. Positive values expire the entity after
-            that many seconds, 0 expires it immediately, and negative values mean no expiry.
+          description: "Time-to-live in seconds. Positive values expire the entity after that many seconds, 0 expires it immediately, and negative values mean no expiry."
           example: -1
       required:
         - domain


### PR DESCRIPTION
## Summary
- Regenerates the KG Write OpenAPI spec/client for collection DELETE endpoints that pass identity fields as query parameters.
- Updates the Go roundtrip example to create scoped entities and delete relationships/entities through the new SDK builders.

## Test plan
- `go test ./...` in `go/kgwrite`
- `go test ./...` in `examples/go/kgwrite-entity-roundtrip`
- `git diff --check`


Made with [Cursor](https://cursor.com)