### PR TITLE
Add systemschemas validate operation to the systemschema client

### DIFF
--- a/go/systemschema/README.md
+++ b/go/systemschema/README.md
@@ -82,6 +82,7 @@ Class | Method | HTTP request | Description
 *SystemKgSchemaAPIAPI* | [**Get**](docs/SystemKgSchemaAPIAPI.md#get) | **Get** /apis/kg.grafana.com/v1alpha1/systemschemas/{domain}/{version} | Get a system schema bundle by domain and version
 *SystemKgSchemaAPIAPI* | [**List**](docs/SystemKgSchemaAPIAPI.md#list) | **Get** /apis/kg.grafana.com/v1alpha1/systemschemas | List all system schema references
 *SystemKgSchemaAPIAPI* | [**Upsert**](docs/SystemKgSchemaAPIAPI.md#upsert) | **Post** /apis/kg.grafana.com/v1alpha1/systemschemas | Push a system schema bundle
+*SystemKgSchemaAPIAPI* | [**Validate**](docs/SystemKgSchemaAPIAPI.md#validate) | **Post** /apis/kg.grafana.com/v1alpha1/systemschemas/validate | Validate a system schema bundle without storing it
 
 
 ## Documentation For Models

--- a/go/systemschema/api/openapi.yaml
+++ b/go/systemschema/api/openapi.yaml
@@ -92,6 +92,41 @@ paths:
       summary: Push a system schema bundle
       tags:
       - System KgSchema API
+  /apis/kg.grafana.com/v1alpha1/systemschemas/validate:
+    post:
+      description: Runs exactly the validation a push would (bean validation plus
+        the structural validator) and persists nothing.
+      operationId: validate
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SystemKgSchemaBundleDto'
+          application/x-yml:
+            schema:
+              $ref: '#/components/schemas/SystemKgSchemaBundleDto'
+          application/x-yaml:
+            schema:
+              $ref: '#/components/schemas/SystemKgSchemaBundleDto'
+        required: true
+      responses:
+        "204":
+          description: Bundle is valid
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+            application/x-yml:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+            application/x-yaml:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+          description: Validation failed
+      summary: Validate a system schema bundle without storing it
+      tags:
+      - System KgSchema API
   /apis/kg.grafana.com/v1alpha1/systemschemas/{domain}/{version}:
     get:
       description: Returns the full schema bundle stored for the given domain/version

--- a/go/systemschema/api_system_kg_schema_api.go
+++ b/go/systemschema/api_system_kg_schema_api.go
@@ -361,3 +361,112 @@ func (a *SystemKgSchemaAPIAPIService) UpsertExecute(r ApiUpsertRequest) (*System
 
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
+
+type ApiValidateRequest struct {
+	ctx                     context.Context
+	ApiService              *SystemKgSchemaAPIAPIService
+	systemKgSchemaBundleDto *SystemKgSchemaBundleDto
+}
+
+func (r ApiValidateRequest) SystemKgSchemaBundleDto(systemKgSchemaBundleDto SystemKgSchemaBundleDto) ApiValidateRequest {
+	r.systemKgSchemaBundleDto = &systemKgSchemaBundleDto
+	return r
+}
+
+func (r ApiValidateRequest) Execute() (*http.Response, error) {
+	return r.ApiService.ValidateExecute(r)
+}
+
+/*
+Validate Validate a system schema bundle without storing it
+
+Runs exactly the validation a push would (bean validation plus the structural validator) and persists nothing.
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiValidateRequest
+*/
+func (a *SystemKgSchemaAPIAPIService) Validate(ctx context.Context) ApiValidateRequest {
+	return ApiValidateRequest{
+		ApiService: a,
+		ctx:        ctx,
+	}
+}
+
+// Execute executes the request
+func (a *SystemKgSchemaAPIAPIService) ValidateExecute(r ApiValidateRequest) (*http.Response, error) {
+	var (
+		localVarHTTPMethod = http.MethodPost
+		localVarPostBody   interface{}
+		formFiles          []formFile
+	)
+
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "SystemKgSchemaAPIAPIService.Validate")
+	if err != nil {
+		return nil, &GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/apis/kg.grafana.com/v1alpha1/systemschemas/validate"
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+	if r.systemKgSchemaBundleDto == nil {
+		return nil, reportError("systemKgSchemaBundleDto is required and must be specified")
+	}
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{"application/json", "application/x-yml", "application/x-yaml"}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{"application/json", "application/x-yml", "application/x-yaml"}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	// body params
+	localVarPostBody = r.systemKgSchemaBundleDto
+	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(req)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarHTTPResponse, err
+	}
+
+	localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
+	if err != nil {
+		return localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		if localVarHTTPResponse.StatusCode == 422 {
+			var v ApiError
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
+		}
+		return localVarHTTPResponse, newErr
+	}
+
+	return localVarHTTPResponse, nil
+}

--- a/go/systemschema/docs/SystemKgSchemaAPIAPI.md
+++ b/go/systemschema/docs/SystemKgSchemaAPIAPI.md
@@ -7,6 +7,7 @@ Method | HTTP request | Description
 [**Get**](SystemKgSchemaAPIAPI.md#Get) | **Get** /apis/kg.grafana.com/v1alpha1/systemschemas/{domain}/{version} | Get a system schema bundle by domain and version
 [**List**](SystemKgSchemaAPIAPI.md#List) | **Get** /apis/kg.grafana.com/v1alpha1/systemschemas | List all system schema references
 [**Upsert**](SystemKgSchemaAPIAPI.md#Upsert) | **Post** /apis/kg.grafana.com/v1alpha1/systemschemas | Push a system schema bundle
+[**Validate**](SystemKgSchemaAPIAPI.md#Validate) | **Post** /apis/kg.grafana.com/v1alpha1/systemschemas/validate | Validate a system schema bundle without storing it
 
 
 
@@ -195,6 +196,70 @@ Name | Type | Description  | Notes
 ### Return type
 
 [**SystemKgSchemaResponseDto**](SystemKgSchemaResponseDto.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json, application/x-yml, application/x-yaml
+- **Accept**: application/json, application/x-yml, application/x-yaml
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)
+[[Back to Model list]](../README.md#documentation-for-models)
+[[Back to README]](../README.md)
+
+
+## Validate
+
+> Validate(ctx).SystemKgSchemaBundleDto(systemKgSchemaBundleDto).Execute()
+
+Validate a system schema bundle without storing it
+
+
+
+### Example
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	openapiclient "github.com/grafana/grafana-asserts-public-clients/go/systemschema"
+)
+
+func main() {
+	systemKgSchemaBundleDto := *openapiclient.NewSystemKgSchemaBundleDto(*openapiclient.NewSchemaDomainDto("Name_example", "Version_example"), []openapiclient.SchemaEntityTypeDto{*openapiclient.NewSchemaEntityTypeDto("Name_example", "Description_example")}, []openapiclient.SchemaRelationshipTypeDto{*openapiclient.NewSchemaRelationshipTypeDto("Name_example", "Description_example", *openapiclient.NewSchemaEndpointDto([]string{"Types_example"}), *openapiclient.NewSchemaEndpointDto([]string{"Types_example"}))}) // SystemKgSchemaBundleDto | 
+
+	configuration := openapiclient.NewConfiguration()
+	apiClient := openapiclient.NewAPIClient(configuration)
+	r, err := apiClient.SystemKgSchemaAPIAPI.Validate(context.Background()).SystemKgSchemaBundleDto(systemKgSchemaBundleDto).Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error when calling `SystemKgSchemaAPIAPI.Validate``: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+	}
+}
+```
+
+### Path Parameters
+
+
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiValidateRequest struct via the builder pattern
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **systemKgSchemaBundleDto** | [**SystemKgSchemaBundleDto**](SystemKgSchemaBundleDto.md) |  | 
+
+### Return type
+
+ (empty response body)
 
 ### Authorization
 

--- a/go/systemschema/test/api_system_kg_schema_api_test.go
+++ b/go/systemschema/test/api_system_kg_schema_api_test.go
@@ -62,4 +62,15 @@ func Test_systemschema_SystemKgSchemaAPIAPIService(t *testing.T) {
 
 	})
 
+	t.Run("Test SystemKgSchemaAPIAPIService Validate", func(t *testing.T) {
+
+		t.Skip("skip test") // remove to run test
+
+		httpRes, err := apiClient.SystemKgSchemaAPIAPI.Validate(context.Background()).Execute()
+
+		require.Nil(t, err)
+		assert.Equal(t, 200, httpRes.StatusCode)
+
+	})
+
 }

--- a/system-schema-openapi.yaml
+++ b/system-schema-openapi.yaml
@@ -90,6 +90,40 @@ paths:
             application/x-yaml:
               schema:
                 $ref: "#/components/schemas/ApiError"
+  /apis/kg.grafana.com/v1alpha1/systemschemas/validate:
+    post:
+      tags:
+        - System KgSchema API
+      summary: Validate a system schema bundle without storing it
+      description: "Runs exactly the validation a push would (bean validation plus the structural validator) and persists nothing."
+      operationId: validate
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SystemKgSchemaBundleDto"
+          application/x-yml:
+            schema:
+              $ref: "#/components/schemas/SystemKgSchemaBundleDto"
+          application/x-yaml:
+            schema:
+              $ref: "#/components/schemas/SystemKgSchemaBundleDto"
+        required: true
+      responses:
+        "204":
+          description: Bundle is valid
+        "422":
+          description: Validation failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+            application/x-yml:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+            application/x-yaml:
+              schema:
+                $ref: "#/components/schemas/ApiError"
   /apis/kg.grafana.com/v1alpha1/systemschemas/{domain}/{version}:
     get:
       tags:


### PR DESCRIPTION
Syncs `system-schema-openapi.yaml` with asserts-adi master, which added `POST /apis/kg.grafana.com/v1alpha1/systemschemas/validate` (grafana/asserts-adi#6724) — a validation-only sibling of upsert: 204 on valid, 422 with the usual `ApiError` `subErrors`, persists nothing.

`go/systemschema` regenerated locally with the exact publish-workflow pipeline (openapi-generator 7.7.0, `modify-spec.sh`, the shared action's Go template, `go mod tidy` + `goimports`) — the diff is purely additive (255 insertions, 0 deletions), so the CI regeneration step should produce no follow-up commit.

New client surface: `SystemKgSchemaAPIAPI.Validate(ctx).SystemKgSchemaBundleDto(dto).Execute()`.

Part of grafana/asserts-adi#6704 (the kg-schema admission webhook will delegate structural validation via this operation).

## Test plan
- [x] `go build ./... && go vet ./...` in `go/systemschema`
- [x] Diff limited to the systemschema client + spec; no churn in gcom/kgwrite